### PR TITLE
feat: harden repo configuration for public visibility

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,4 @@
 /packages/agency-plugin-humancy/       @generacy-ai/core-team
 /packages/agency-plugin-npm/           @generacy-ai/core-team
 /packages/agency-plugin-spec-kit/      @generacy-ai/core-team
+/packages/claude-plugin-agency-spec-kit/ @generacy-ai/core-team

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
@@ -32,7 +32,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
@@ -46,7 +46,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
@@ -59,7 +59,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,7 +1,9 @@
 name: Publish Preview
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [develop]
 
 concurrency:
@@ -16,32 +18,50 @@ jobs:
   preview:
     name: Preview Publish
     runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - name: Check for changesets
+        id: changesets
+        run: |
+          CHANGESET_FILES=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | head -1)
+          if [ -z "$CHANGESET_FILES" ]; then
+            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
+            echo "No changeset files found, skipping preview publish"
+          else
+            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
+            echo "Changeset files found, proceeding with preview publish"
+          fi
+
+      - name: Setup pnpm
+        if: steps.changesets.outputs.has_changesets == 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: steps.changesets.outputs.has_changesets == 'true'
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
-      - run: npm install -g npm@latest
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
+      - name: Update npm
+        if: steps.changesets.outputs.has_changesets == 'true'
+        run: npm install -g npm@latest
 
-      # Check if any changeset files exist
-      - name: Check for changesets
-        id: changesets
-        run: |
-          CHANGESET_FILES=$(find .changeset -name '*.md' ! -name 'README.md' | head -1)
-          if [ -n "$CHANGESET_FILES" ]; then
-            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Install dependencies
+        if: steps.changesets.outputs.has_changesets == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        if: steps.changesets.outputs.has_changesets == 'true'
+        run: pnpm build
 
       - name: Publish preview snapshots
         if: steps.changesets.outputs.has_changesets == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          registry-url: https://registry.npmjs.org
 
       - run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
@@ -36,7 +35,7 @@ jobs:
       - name: Create Release PR or Publish
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish --provenance
+          publish: pnpm changeset publish
           title: "chore: version packages"
           commit: "chore: version packages"
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ coverage/
 
 # VS Code extension packages
 *.vsix
+
+# Secrets scan reports
+gitleaks-report.json

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+title = "Gitleaks Configuration"
+
+[allowlist]
+  description = "Global allowlist"
+  paths = [
+    '''pnpm-lock\.yaml''',
+    '''\.gitleaks\.toml''',
+  ]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Agency
+
+Agent environment curation for the [Generacy](https://generacy.ai) ecosystem. Agency is an MCP (Model Context Protocol) server and plugin system that gives AI development agents access to build, test, source control, and infrastructure tools -- and gives humans a way to curate, test, and refine that agent environment.
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| [`@generacy-ai/agency`](packages/agency/) | Core MCP server with plugin-based tool registration |
+| [`@generacy-ai/agency-extension`](packages/agency-extension/) | VS Code extension for plugin configuration and activity monitoring |
+| [`@generacy-ai/agency-plugin-git`](packages/agency-plugin-git/) | Git source control tools |
+| [`@generacy-ai/agency-plugin-docker`](packages/agency-plugin-docker/) | Docker operations tools |
+| [`@generacy-ai/agency-plugin-firebase`](packages/agency-plugin-firebase/) | Firebase operations tools |
+| [`@generacy-ai/agency-plugin-npm`](packages/agency-plugin-npm/) | npm ecosystem operations tools |
+| [`@generacy-ai/agency-plugin-humancy`](packages/agency-plugin-humancy/) | Human-in-the-loop integration |
+| [`@generacy-ai/agency-plugin-spec-kit`](packages/agency-plugin-spec-kit/) | Structured feature development tools |
+
+## Getting Started
+
+```bash
+npm install @generacy-ai/agency
+```
+
+## Development
+
+This repo uses [pnpm](https://pnpm.io/) workspaces with [Turbo](https://turbo.build/) for builds.
+
+```bash
+pnpm install
+pnpm build
+pnpm test
+pnpm lint
+```
+
+## Contributing
+
+We welcome contributions. Please open an issue or pull request.
+
+All changes should include a [changeset](https://github.com/changesets/changesets) (`pnpm changeset`) describing the change.
+
+## License
+
+[MIT](LICENSE) -- Copyright 2026 The Generacy AI Authors

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ This project is pre-1.0. Only the latest released version receives security upda
 
 ## Response Process
 
-1. Your report will be acknowledged as soon as possible.
+1. Your report will be acknowledged within 5 business days.
 2. We will investigate and validate the reported vulnerability.
 3. A fix will be developed and tested.
 4. A security advisory will be published alongside the fix.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@generacy-ai/agency-monorepo",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@9.15.4",
   "engines": {


### PR DESCRIPTION
## Summary

- Gate preview publish on CI success via `workflow_run` trigger (previously could publish broken code on direct push)
- Remove `registry-url` and `--provenance` from release workflow to avoid `.npmrc` conflicts with `changesets/action`
- Add `.gitleaks.toml` secrets scanning config and `.gitignore` entry for scan reports
- Standardize CI Node version from 20 to 22 across all workflows
- Add `license` field to root `package.json`
- Write public-facing README with package table, install, dev, and contributing sections
- Add concrete 5 business day response timeline to SECURITY.md
- Add missing `claude-plugin-agency-spec-kit` to CODEOWNERS

## Post-merge manual steps

After making the repo public, configure via GitHub UI:
1. **Branch ruleset** on develop + main (1 approving review, dismiss stale reviews, prevent deletion)
2. **Enable "Automatically delete head branches"** in repo settings
3. **Enable secret scanning + push protection** under Code security
4. **Enable Dependabot security updates** under Code security

## Test plan

- [ ] CI workflow runs successfully with Node 22
- [ ] Preview publish triggers only after CI passes (not on direct push)
- [ ] Release workflow publishes without `.npmrc` conflicts
- [ ] Gitleaks scan passes with new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)