### PR TITLE
fix: remove invalid package from changeset ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,5 @@
   "access": "public",
   "baseBranch": "develop",
   "updateInternalDependencies": "patch",
-  "ignore": [
-    "claude-plugin-agency-spec-kit"
-  ]
+  "ignore": []
 }


### PR DESCRIPTION
## Summary

- Remove `claude-plugin-agency-spec-kit` from the `ignore` array in `.changeset/config.json`
- This package directory has no `package.json` (only a README.md and `commands/` directory) and is not a valid workspace package
- Its presence causes `changeset version --snapshot preview` to fail with a `ValidationError` because changesets cannot resolve it as a workspace package
- This has been silently blocking all npm preview publishes

## Test plan

- [ ] Verify `pnpm changeset version --snapshot preview` no longer fails with a ValidationError
- [ ] Verify CI preview publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)