### PR TITLE
fix: rename extension package to agency for correct VS Code ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           CURRENT_VERSION=$(node -p "require('./packages/agency-extension/package.json').version")
           echo "current=$CURRENT_VERSION"
-          if npx @vscode/vsce show generacy-ai.agency-extension --json 2>/dev/null | node -e "
+          if npx @vscode/vsce show generacy-ai.agency --json 2>/dev/null | node -e "
             const data = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
             const versions = data.versions?.map(v => v.version) || [];
             process.exit(versions.includes('$CURRENT_VERSION') ? 0 : 1);
@@ -115,19 +115,19 @@ jobs:
 
       - name: Publish extension (pre-release)
         if: steps.pat.outputs.has_pat == 'true' && steps.version.outputs.exists != 'true'
-        run: pnpm --filter agency-extension publish --pre-release
+        run: pnpm --filter agency publish --pre-release
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Package VSIX
         if: steps.pat.outputs.has_pat == 'true'
-        run: pnpm --filter agency-extension package
+        run: pnpm --filter agency package
 
       - name: Upload VSIX artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: agency-extension-vsix
+          name: agency-vsix
           path: packages/agency-extension/*.vsix
           if-no-files-found: ignore
           retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,6 @@ jobs:
 
       - name: Publish extension to Marketplace
         if: steps.changesets.outputs.published == 'true' && env.VSCE_PAT != ''
-        run: pnpm --filter agency-extension exec vsce publish --no-dependencies
+        run: pnpm --filter agency exec vsce publish --no-dependencies
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent environment curation for the [Generacy](https://generacy.ai) ecosystem. Ag
 | Package | Description |
 |---------|-------------|
 | [`@generacy-ai/agency`](packages/agency/) | Core MCP server with plugin-based tool registration |
-| [`@generacy-ai/agency-extension`](packages/agency-extension/) | VS Code extension for plugin configuration and activity monitoring |
+| [`agency`](packages/agency-extension/) | VS Code extension for plugin configuration and activity monitoring |
 | [`@generacy-ai/agency-plugin-git`](packages/agency-plugin-git/) | Git source control tools |
 | [`@generacy-ai/agency-plugin-docker`](packages/agency-plugin-docker/) | Docker operations tools |
 | [`@generacy-ai/agency-plugin-firebase`](packages/agency-plugin-firebase/) | Firebase operations tools |

--- a/packages/agency-extension/PUBLISHING.md
+++ b/packages/agency-extension/PUBLISHING.md
@@ -1,6 +1,6 @@
 # Publishing: Agency VS Code Extension
 
-Extension ID: `generacy-ai.agency-extension`
+Extension ID: `generacy-ai.agency`
 Publisher: `generacy-ai`
 
 ## Release Streams
@@ -30,7 +30,7 @@ Extension versioning is managed by [changesets](https://github.com/changesets/ch
 
 ```bash
 pnpm changeset
-# Select agency-extension when prompted
+# Select agency when prompted
 ```
 
 Changesets bumps the version in `package.json`. The `private: true` field prevents changesets from attempting an npm publish — the extension is published to the VS Code Marketplace only.
@@ -47,10 +47,10 @@ Both workflows skip gracefully with a warning if `VSCE_PAT` is not configured.
 
 ```bash
 # Package without publishing (for testing)
-pnpm --filter agency-extension package
+pnpm --filter agency package
 
 # Publish to Marketplace (requires VSCE_PAT env var)
-VSCE_PAT=<your-token> pnpm --filter agency-extension publish
+VSCE_PAT=<your-token> pnpm --filter agency publish
 ```
 
 ## Recovery Procedure

--- a/packages/agency-extension/package.json
+++ b/packages/agency-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agency-extension",
+  "name": "agency",
   "displayName": "Agency",
   "description": "Plugin configuration, in-situ MCP testing, and activity monitoring for AI development agents",
   "version": "0.0.0",

--- a/packages/agency-extension/src/constants.ts
+++ b/packages/agency-extension/src/constants.ts
@@ -3,7 +3,7 @@
  */
 
 /** Extension identifier */
-export const EXTENSION_ID = 'generacy-ai.agency-extension';
+export const EXTENSION_ID = 'generacy-ai.agency';
 
 /** Extension display name */
 export const EXTENSION_NAME = 'Agency';

--- a/packages/agency-extension/src/mcp/StdioClient.ts
+++ b/packages/agency-extension/src/mcp/StdioClient.ts
@@ -137,7 +137,7 @@ export class StdioClient implements McpClient {
 
   constructor(config: StdioClientConfig) {
     this.config = {
-      clientName: config.clientName ?? 'agency-extension',
+      clientName: config.clientName ?? 'agency',
       clientVersion: config.clientVersion ?? '0.0.0',
       defaultExecutionTimeout:
         config.defaultExecutionTimeout ?? DEFAULT_CONFIG.EXECUTION_TIMEOUT,

--- a/packages/agency-extension/src/services/McpClientService.ts
+++ b/packages/agency-extension/src/services/McpClientService.ts
@@ -485,7 +485,7 @@ export class McpClientService {
       // Create MCP client
       this._client = new Client(
         {
-          name: 'agency-extension',
+          name: 'agency',
           version: '1.0.0',
         },
         {


### PR DESCRIPTION
## Summary

- Rename `package.json` name from `agency-extension` to `agency` so the VS Code extension ID becomes `generacy-ai.agency` instead of `generacy-ai.agency-extension`
- Update all `pnpm --filter agency-extension` references to `pnpm --filter agency` in CI and release workflows
- Update `generacy-ai.agency-extension` to `generacy-ai.agency` in the `vsce show` check, constants.ts EXTENSION_ID, and PUBLISHING.md
- Update MCP client name strings in McpClientService.ts and StdioClient.ts
- Update README.md package table reference

Closes #134

## Test plan

- [ ] Verify `pnpm --filter agency build` resolves correctly
- [ ] Verify `pnpm --filter agency package` produces a valid VSIX
- [ ] Verify the VSIX contains the correct extension ID `generacy-ai.agency`
- [ ] Verify CI workflow runs successfully with updated filter names

🤖 Generated with [Claude Code](https://claude.com/claude-code)