### PR TITLE
fix: update license from MIT to Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@generacy-ai/agency-monorepo",
   "private": true,
-  "license": "MIT",
+  "license": "Apache-2.0",
   "type": "module",
   "packageManager": "pnpm@9.15.4",
   "engines": {

--- a/packages/agency-extension/package.json
+++ b/packages/agency-extension/package.json
@@ -4,7 +4,7 @@
   "description": "Plugin configuration, in-situ MCP testing, and activity monitoring for AI development agents",
   "version": "0.0.0",
   "publisher": "generacy-ai",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "private": true,
   "icon": "media/icon.png",
   "galleryBanner": {

--- a/packages/agency-plugin-docker/package.json
+++ b/packages/agency-plugin-docker/package.json
@@ -27,7 +27,7 @@
   },
   "keywords": ["mcp", "agent", "generacy", "docker"],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/agency-plugin-firebase/package.json
+++ b/packages/agency-plugin-firebase/package.json
@@ -27,7 +27,7 @@
   },
   "keywords": ["mcp", "agent", "generacy", "firebase"],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/agency-plugin-git/package.json
+++ b/packages/agency-plugin-git/package.json
@@ -28,7 +28,7 @@
   },
   "keywords": ["mcp", "agent", "generacy", "git", "source-control"],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/agency-plugin-humancy/package.json
+++ b/packages/agency-plugin-humancy/package.json
@@ -27,7 +27,7 @@
   },
   "keywords": ["mcp", "agent", "generacy", "humancy", "human-in-the-loop"],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/agency-plugin-npm/package.json
+++ b/packages/agency-plugin-npm/package.json
@@ -27,7 +27,7 @@
   },
   "keywords": ["mcp", "agent", "generacy", "npm", "build", "test"],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/agency-plugin-spec-kit/package.json
+++ b/packages/agency-plugin-spec-kit/package.json
@@ -39,7 +39,7 @@
     "feature"
   ],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/agency/package.json
+++ b/packages/agency/package.json
@@ -69,7 +69,7 @@
     "generacy"
   ],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Updates all 9 `package.json` files from MIT to Apache-2.0 license

## Test plan
- [ ] Verify all package.json files show `"license": "Apache-2.0"`
- [ ] No functional changes — license metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)