### PR TITLE
fix: always publish preview snapshots on develop push

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -27,20 +27,29 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check for changesets
-        id: changesets
+      - name: Ensure changesets for preview
         run: |
           CHANGESET_FILES=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | head -1)
-          if [ -z "$CHANGESET_FILES" ]; then
-            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
-            echo "No changeset files found, skipping preview publish"
-          else
-            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
+          if [ -n "$CHANGESET_FILES" ]; then
             echo "Changeset files found, proceeding with preview publish"
+          else
+            echo "No changeset files found, generating synthetic changeset"
+            node -e "
+              const fs = require('fs'), path = require('path');
+              const config = JSON.parse(fs.readFileSync('.changeset/config.json', 'utf8'));
+              const ignore = new Set(config.ignore || []);
+              const pkgs = fs.readdirSync('packages')
+                .map(d => path.join('packages', d, 'package.json'))
+                .filter(p => fs.existsSync(p))
+                .map(p => JSON.parse(fs.readFileSync(p, 'utf8')))
+                .filter(p => !p.private && p.name && !ignore.has(p.name));
+              const lines = ['---', ...pkgs.map(p => '\"' + p.name + '\": patch'), '---', '', 'Preview publish (synthetic)', ''];
+              fs.writeFileSync('.changeset/preview-publish.md', lines.join('\n'));
+              console.log('Created synthetic changeset for ' + pkgs.length + ' packages');
+            "
           fi
 
       - name: Verify latency dependency
-        if: steps.changesets.outputs.has_changesets == 'true'
         id: latency
         run: |
           if npm view @generacy-ai/latency@preview version 2>/dev/null; then
@@ -52,11 +61,11 @@ jobs:
           fi
 
       - name: Setup pnpm
-        if: steps.changesets.outputs.has_changesets == 'true' && steps.latency.outputs.found == 'true'
+        if: steps.latency.outputs.found == 'true'
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        if: steps.changesets.outputs.has_changesets == 'true' && steps.latency.outputs.found == 'true'
+        if: steps.latency.outputs.found == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -64,19 +73,19 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Update npm
-        if: steps.changesets.outputs.has_changesets == 'true' && steps.latency.outputs.found == 'true'
+        if: steps.latency.outputs.found == 'true'
         run: npm install -g npm@latest
 
       - name: Install dependencies
-        if: steps.changesets.outputs.has_changesets == 'true' && steps.latency.outputs.found == 'true'
+        if: steps.latency.outputs.found == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        if: steps.changesets.outputs.has_changesets == 'true' && steps.latency.outputs.found == 'true'
+        if: steps.latency.outputs.found == 'true'
         run: pnpm build
 
       - name: Publish preview snapshots
-        if: steps.changesets.outputs.has_changesets == 'true' && steps.latency.outputs.found == 'true'
+        if: steps.latency.outputs.found == 'true'
         run: |
           pnpm changeset version --snapshot preview
           pnpm changeset publish --tag preview --provenance


### PR DESCRIPTION
## Summary

- When no changeset files exist on `develop` (e.g., after changesets are consumed by a release merge), the publish-preview workflow now generates a synthetic patch changeset for all public, non-ignored packages
- Removes `has_changesets` gate from all steps while preserving the latency dependency check
- Mirrors the same fix applied to the generacy repo

## Test plan

- [ ] Merge this PR and verify the Publish Preview workflow runs successfully
- [ ] Confirm `npm view @generacy-ai/agency@preview` returns a valid version
- [ ] Verify the latency dependency gate still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)