### PR TITLE
feat: add Claude Code marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "generacy-marketplace",
+  "description": "Generacy development tools and spec-kit commands for Claude Code",
+  "owner": {
+    "name": "Generacy AI",
+    "email": "support@generacy.ai"
+  },
+  "plugins": [
+    {
+      "name": "agency-spec-kit",
+      "description": "Specification-driven development commands using Agency MCP tools",
+      "author": {
+        "name": "Generacy AI",
+        "email": "support@generacy.ai"
+      },
+      "source": "./packages/claude-plugin-agency-spec-kit",
+      "category": "development"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` at the repo root so Claude Code can discover plugins hosted in this repo
- Required for `claude plugin marketplace add generacy-ai/agency` and `claude plugin install agency-spec-kit@generacy-marketplace` to work
- Without this, external projects (using npm-installed packages) could not install the spec-kit plugin

## Context
This is a dependency for generacy-ai/generacy#TBD which fixes the Phase 4 plugin setup for external developer onboarding.

## Test plan
- [ ] `claude plugin validate /path/to/agency` passes
- [ ] `claude plugin marketplace add generacy-ai/agency` succeeds after merge to develop
- [ ] `claude plugin install agency-spec-kit@generacy-marketplace` installs the plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)