### PR TITLE
fix: remove invalid 'requires' key from plugin manifest

### DIFF
--- a/packages/claude-plugin-agency-spec-kit/.claude-plugin/plugin.json
+++ b/packages/claude-plugin-agency-spec-kit/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "agency-spec-kit",
-  "version": "0.0.1",
   "description": "Specification-driven development commands using Agency MCP tools",
-  "requires": {
-    "mcp": ["@generacy-ai/agency-plugin-spec-kit"]
+  "author": {
+    "name": "Generacy AI",
+    "email": "support@generacy.ai"
   }
 }


### PR DESCRIPTION
## Summary
- Removes the `requires` field from `packages/claude-plugin-agency-spec-kit/.claude-plugin/plugin.json`
- Claude Code's plugin schema is strict — `requires` is not a recognized key, causing install to fail with: `Unrecognized key: "requires"`
- Also removes `version` from plugin.json (version is managed via marketplace.json entry)
- Adds `author` field per the documented schema

## Test plan
- [ ] `claude plugin validate ./packages/claude-plugin-agency-spec-kit` passes
- [ ] `claude plugin install agency-spec-kit@generacy-marketplace --scope user` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)