### PR TITLE
fix: validate @latest peer-dep consistency after each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,67 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Validate latest peer-dep consistency
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          node - <<'EOF'
+          const { execSync } = require('child_process');
+          const semver = require('semver');
+
+          const PACKAGES = [
+            '@generacy-ai/agency',
+            '@generacy-ai/agency-plugin-spec-kit',
+            '@generacy-ai/agency-plugin-humancy',
+            '@generacy-ai/agency-plugin-docker',
+            '@generacy-ai/agency-plugin-firebase',
+            '@generacy-ai/agency-plugin-git',
+            '@generacy-ai/agency-plugin-npm',
+            '@generacy-ai/agency-extension',
+          ];
+
+          function npmInfo(pkg) {
+            try {
+              return JSON.parse(execSync(`npm info ${pkg}@latest --json 2>/dev/null`, { encoding: 'utf8' }));
+            } catch {
+              return null;
+            }
+          }
+
+          const infos = {};
+          for (const pkg of PACKAGES) {
+            infos[pkg] = npmInfo(pkg);
+            if (infos[pkg]) {
+              console.log(`  ${pkg}@latest = ${infos[pkg].version}`);
+            } else {
+              console.log(`  ${pkg}@latest = (not on npm)`);
+            }
+          }
+
+          let failed = false;
+          for (const pkg of PACKAGES) {
+            const info = infos[pkg];
+            if (!info || !info.peerDependencies) continue;
+            for (const [peer, range] of Object.entries(info.peerDependencies)) {
+              if (!infos[peer]) continue;
+              const peerVersion = infos[peer]?.version;
+              if (!peerVersion) continue;
+              // workspace:* becomes a concrete range after publish; skip if not semver
+              if (!semver.validRange(range)) continue;
+              if (!semver.satisfies(peerVersion, range)) {
+                console.error(`::error::Peer dep conflict: ${pkg}@${info.version} requires ${peer}@${range} but @latest is ${peerVersion}`);
+                failed = true;
+              }
+            }
+          }
+
+          if (failed) {
+            console.error('One or more @latest packages have unresolvable peer dependencies.');
+            console.error('Re-run the release after bumping all affected packages together in a single changeset.');
+            process.exit(1);
+          }
+          console.log('All @latest peer dependencies are consistent.');
+          EOF
+
       - name: Publish extension to Marketplace
         if: steps.changesets.outputs.published == 'true' && env.VSCE_PAT != ''
         run: pnpm --filter agency exec vsce publish --no-dependencies


### PR DESCRIPTION
## Problem

The Mar 2 release bumped `agency-plugin-spec-kit` and `agency-plugin-humancy` without also bumping `agency`. That left `agency@latest` pointing at the Feb 28 build while `agency-plugin-spec-kit@latest` declared a peer dep on the Mar 2 build of `agency`. Concretely:

```
npm dist-tags before Apr 7
@generacy-ai/agency@latest                = 0.0.0-preview-20260228204303  (Feb 28)
@generacy-ai/agency-plugin-spec-kit@latest = 0.0.0-preview-20260302182740  (Mar 2)
  peerDependencies: { "@generacy-ai/agency": ">=0.0.0-preview-20260302182740" }
```

A fresh `npm install @generacy-ai/agency-plugin-spec-kit@latest` fails because the peer dep is unsatisfied. `@latest` is essentially broken; only `@preview` works right now since all four packages were published together on Apr 7.

The root cause is that changesets only bumps packages that have pending changesets — so a PR that only touches plugins can create a partially-advanced `latest` state.

## Fix

Add a **post-publish validation step** that runs after `changesets/action` publishes. It:

1. Fetches `npm info @generacy-ai/<pkg>@latest` for every package in this workspace.
2. Iterates all `peerDependencies` entries and checks that the currently-published `@latest` version satisfies each declared range.
3. Fails the workflow with a clear `::error::` annotation if any conflict is found, telling the maintainer to cut a follow-up release including all affected packages in a single changeset.

The step is **no-op on the happy path** (all peer deps satisfied) and only runs when changesets actually published something (`steps.changesets.outputs.published == 'true'`).

## What this does not fix

The current npm registry state (`agency@latest` = Feb 28) is not changed by this PR. As of Apr 7 `@preview` is the only working tag. A follow-up stable release that bumps all four packages together will restore `@latest`.

Made with [Cursor](https://cursor.com)