### PR TITLE
fix(release): publish to npm `stable` dist-tag from main

### DIFF
--- a/.changeset/initial-stable-release.md
+++ b/.changeset/initial-stable-release.md
@@ -1,0 +1,6 @@
+---
+"@generacy-ai/agency": patch
+"@generacy-ai/agency-plugin-spec-kit": patch
+---
+
+Initial `stable` dist-tag release. Publishes current main under the `stable` channel so the orchestrator's `npm install @generacy-ai/<pkg>@stable` resolves.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish --provenance
+          publish: pnpm changeset publish --tag stable --provenance
           title: "chore: version packages"
           commit: "chore: version packages"
         env:


### PR DESCRIPTION
## Summary

- Adds `--tag stable` to `pnpm changeset publish` in [release.yml](.github/workflows/release.yml) so merges to `main` land on the `stable` npm dist-tag (not `latest`).
- Adds an initial changeset for `@generacy-ai/agency` and `@generacy-ai/agency-plugin-spec-kit` so the next merge to `main` actually triggers a version+publish cycle.

## Why

The devcontainer orchestrator entrypoint runs `npm install @generacy-ai/*@stable` (see `cluster-base/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh`, `CHANNEL` defaults to `stable`). Current npm dist-tags for the four orchestrator packages only contain `latest` and `preview` — `stable` was never populated, so the install fails with `ETARGET`.

Once this PR merges, `changesets/action` will open a "Version Packages" PR; merging that PR publishes `@generacy-ai/agency@0.0.1` and `@generacy-ai/agency-plugin-spec-kit@0.0.1` under the `stable` tag.

## Notes

- `latest` will still point at the old preview snapshot after this change. If we want `npm install @generacy-ai/agency` (no tag) to resolve to the real release, a follow-up can alias `latest → stable` via `npm dist-tag add`.
- The post-publish peer-dep validation step still queries `@latest`. It runs against pre-existing preview artifacts and remains internally consistent — left unchanged to keep this PR surgical.
- No code changes — only the workflow + a changeset metadata file.

## Test plan

- [ ] After merge, confirm `changesets/action` opens the Version Packages PR
- [ ] Merge Version Packages PR
- [ ] Verify `npm view @generacy-ai/agency dist-tags` includes `stable`
- [ ] Verify `npm view @generacy-ai/agency-plugin-spec-kit dist-tags` includes `stable`
- [ ] Rebuild orchestrator container and confirm `npm install` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)