### PR TITLE
chore: sync release workflow fixes from main back to develop

### DIFF
--- a/.changeset/initial-stable-release.md
+++ b/.changeset/initial-stable-release.md
@@ -1,0 +1,6 @@
+---
+"@generacy-ai/agency": patch
+"@generacy-ai/agency-plugin-spec-kit": patch
+---
+
+Initial `stable` dist-tag release. Publishes current main under the `stable` channel so the orchestrator's `npm install @generacy-ai/<pkg>@stable` resolves.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,67 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Validate latest peer-dep consistency
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          node - <<'EOF'
+          const { execSync } = require('child_process');
+          const semver = require('semver');
+
+          const PACKAGES = [
+            '@generacy-ai/agency',
+            '@generacy-ai/agency-plugin-spec-kit',
+            '@generacy-ai/agency-plugin-humancy',
+            '@generacy-ai/agency-plugin-docker',
+            '@generacy-ai/agency-plugin-firebase',
+            '@generacy-ai/agency-plugin-git',
+            '@generacy-ai/agency-plugin-npm',
+            '@generacy-ai/agency-extension',
+          ];
+
+          function npmInfo(pkg) {
+            try {
+              return JSON.parse(execSync(`npm info ${pkg}@latest --json 2>/dev/null`, { encoding: 'utf8' }));
+            } catch {
+              return null;
+            }
+          }
+
+          const infos = {};
+          for (const pkg of PACKAGES) {
+            infos[pkg] = npmInfo(pkg);
+            if (infos[pkg]) {
+              console.log(`  ${pkg}@latest = ${infos[pkg].version}`);
+            } else {
+              console.log(`  ${pkg}@latest = (not on npm)`);
+            }
+          }
+
+          let failed = false;
+          for (const pkg of PACKAGES) {
+            const info = infos[pkg];
+            if (!info || !info.peerDependencies) continue;
+            for (const [peer, range] of Object.entries(info.peerDependencies)) {
+              if (!infos[peer]) continue;
+              const peerVersion = infos[peer]?.version;
+              if (!peerVersion) continue;
+              // workspace:* becomes a concrete range after publish; skip if not semver
+              if (!semver.validRange(range)) continue;
+              if (!semver.satisfies(peerVersion, range)) {
+                console.error(`::error::Peer dep conflict: ${pkg}@${info.version} requires ${peer}@${range} but @latest is ${peerVersion}`);
+                failed = true;
+              }
+            }
+          }
+
+          if (failed) {
+            console.error('One or more @latest packages have unresolvable peer dependencies.');
+            console.error('Re-run the release after bumping all affected packages together in a single changeset.');
+            process.exit(1);
+          }
+          console.log('All @latest peer dependencies are consistent.');
+          EOF
+
       - name: Publish extension to Marketplace
         if: steps.changesets.outputs.published == 'true' && env.VSCE_PAT != ''
         run: pnpm --filter agency exec vsce publish --no-dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish --provenance
+          publish: pnpm changeset publish --tag stable --provenance
           title: "chore: version packages"
           commit: "chore: version packages"
         env:


### PR DESCRIPTION
## Summary

Brings two main-only release-workflow fixes back to develop so the next CI-on-develop run uses the same `release.yml` as main:

1. **`--tag stable` for `pnpm changeset publish`** (from #340, 2026-04-17). Without this, even when a publish does fire, packages land on `latest` — the orchestrator's `npm install @generacy-ai/*@stable` fails with `ETARGET`.
2. **`Validate @latest peer-dep consistency`** post-publish step (from #339, 2026-04-14). Catches peer-dep mismatches across the agency-* packages.

Also pulls in the `initial-stable-release.md` changeset (added by #340) so develop's view of pending releases matches main.

## Why this is needed

Today's develop→main merge (#342) ran the Release workflow at [run 26113430608](https://github.com/generacy-ai/agency/actions/runs/26113430608). The run logs show:

```
publish: pnpm changeset publish --provenance
```

— no `--tag stable`, despite main's `release.yml` having it. The workflow_run fired with `head_branch=develop`, and the workflow file used was develop's stale version, not main's. As a result, no agency package has ever landed on the `stable` dist-tag (all 8 are still at `0.0.0-preview-…`).

The two fixes lived only on main because they were PR'd directly to main and never back-merged.

## What this changes

- [.github/workflows/release.yml](.github/workflows/release.yml) — develop now matches main exactly.
- [.changeset/initial-stable-release.md](.changeset/initial-stable-release.md) — new (mirrors what's on main).

No source code touched.

## Test plan

- [ ] After merge to develop, then develop→main, confirm Release workflow runs with `--tag stable`
- [ ] Confirm the existing open Release PR #338 can finally publish from main
- [ ] Verify `npm view @generacy-ai/agency dist-tags` includes `stable` after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)