### PR TITLE
test(docker): increase timeouts for cold Docker daemon on CI

### DIFF
--- a/packages/agency-plugin-docker/src/__tests__/integration/docker.integration.test.ts
+++ b/packages/agency-plugin-docker/src/__tests__/integration/docker.integration.test.ts
@@ -14,7 +14,7 @@ import { dockerPlugin, dockerTools, dockerPluginManifest } from '../../index.js'
  */
 async function isDockerAvailable(): Promise<boolean> {
   try {
-    await execa('docker', ['info'], { timeout: 5000 });
+    await execa('docker', ['info'], { timeout: 15000 });
     return true;
   } catch {
     return false;
@@ -113,7 +113,7 @@ describe('Docker Plugin Integration', () => {
         const available = await isDockerAvailable();
         expect(available).toBe(true);
       }),
-      10000
+      30000
     );
   });
 
@@ -177,7 +177,7 @@ describe('Docker Plugin Integration', () => {
         const text = (result.content[0] as { text: string }).text;
         expect(text).toContain('[NOT_FOUND]');
       }),
-      10000
+      30000
     );
   });
 });


### PR DESCRIPTION
## Summary

`agency-plugin-docker`'s `can detect Docker daemon` integration test [intermittently times out](https://github.com/generacy-ai/agency/actions/runs/26118244881) at 10s on `ubuntu-latest` runners. CI on main after PR #344 failed on attempt 1 here; a re-run passed. Same test, same workflow, different timing — classic flake.

## Root cause

GitHub-hosted runners have Docker pre-installed (no DinD needed) but the **first** `docker info` call on a cold daemon enumerates networks, plugins, storage driver, etc. and routinely takes 3-5s. The test design at [docker.integration.test.ts:109-117](packages/agency-plugin-docker/src/__tests__/integration/docker.integration.test.ts#L109-L117) compounds this:

```ts
it(
  'can detect Docker daemon',
  skipIfNoDocker(async () => {                      // ← 1st isDockerAvailable() call (max 5s)
    const available = await isDockerAvailable();    // ← 2nd isDockerAvailable() call (max 5s)
    expect(available).toBe(true);
  }),
  10000                                              // ← test timeout
);
```

Two serial cold `docker info` calls plus vitest overhead → can exceed 10s. Either `execa` SIGTERMs mid-enumeration (returns false → test "skipped" but not really) or vitest's outer timeout fires first.

## Fix (minimal)

Three single-number changes, no logic changes:

1. `execa('docker', ['info'], { timeout: 5000 })` → `timeout: 15000` — enough headroom for one cold call to finish.
2. `it('can detect Docker daemon', …, 10000)` → `30000` — survives two serial cold calls.
3. `it('handles non-existent container gracefully', …, 10000)` → `30000` — same wrapper pattern, same risk.

The `can run and stop a container` test was already at 30s and unaffected.

I deliberately did **not** touch the double-`isDockerAvailable()` pattern — that's a separate, cleaner refactor and the user wanted the lowest-risk change.

## Test plan

- [ ] CI passes on this PR
- [ ] Re-running CI on main pulls cleanly through the test step
- [ ] No regression in the existing 3 integration tests

## Related

- Surfaced while investigating why agency packages had no `@stable` dist-tag — the Release workflow needs `workflow_run.conclusion == 'success'` on CI, which this flake was blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)