### PR TITLE
fix(release): add semver as a root devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@typescript-eslint/eslint-plugin": "^8.21.0",
     "@typescript-eslint/parser": "^8.21.0",
     "eslint": "^9.18.0",
+    "semver": "^7.8.0",
     "turbo": "^2.3.4",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       eslint:
         specifier: ^9.18.0
         version: 9.39.2
+      semver:
+        specifier: ^7.8.0
+        version: 7.8.0
       turbo:
         specifier: ^2.3.4
         version: 2.7.5
@@ -2356,6 +2359,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -2883,7 +2891,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.8.0
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -2892,7 +2900,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.3
+      semver: 7.8.0
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -2925,7 +2933,7 @@ snapshots:
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.8.0
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
@@ -2950,7 +2958,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.3
+      semver: 7.8.0
 
   '@changesets/get-release-plan@4.0.14':
     dependencies:
@@ -3535,7 +3543,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.53.0
       debug: 4.4.3
       minimatch: 9.0.5
-      semver: 7.7.3
+      semver: 7.8.0
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -3666,7 +3674,7 @@ snapshots:
       minimatch: 3.1.2
       parse-semver: 1.1.1
       read: 1.0.7
-      semver: 7.7.3
+      semver: 7.8.0
       tmp: 0.2.5
       typed-rest-client: 1.8.11
       url-join: 4.0.1
@@ -4572,7 +4580,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.3
+      semver: 7.8.0
 
   jwa@2.0.1:
     dependencies:
@@ -4721,7 +4729,7 @@ snapshots:
 
   node-abi@3.87.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.0
     optional: true
 
   node-addon-api@4.3.0:
@@ -5007,6 +5015,8 @@ snapshots:
   semver@5.7.2: {}
 
   semver@7.7.3: {}
+
+  semver@7.8.0: {}
 
   send@1.2.1:
     dependencies:


### PR DESCRIPTION
## Summary

Today's agency Release run [26122876683](https://github.com/generacy-ai/agency/actions/runs/26122876683) failed in the post-publish `Validate latest peer-dep consistency` step with:

```
Error: Cannot find module 'semver'
Require stack:
- /home/runner/work/agency/agency/[stdin]
```

The validation step (added in #339, April 2026) does:

```js
node - <<'EOF'
const { execSync } = require('child_process');
const semver = require('semver');
…
```

…from the repo root. `semver` was only present *transitively* (via `@changesets/cli`) in `node_modules/`, but `require('semver')` from a node-script-as-stdin resolves only top-level deps.

Why it didn't fail before: the step is gated on `if: steps.changesets.outputs.published == 'true'`. Until today, every agency Release run created the version-packages PR instead of actually publishing, so `published` was always `'false'` and this step never executed. Today's run was the **first real publish** — first time the step ran, first time the missing dep surfaced.

The publish itself succeeded. All 7 packages now have `stable` dist-tags:

```
@generacy-ai/agency                    stable=0.1.1
@generacy-ai/agency-plugin-docker      stable=1.0.1
@generacy-ai/agency-plugin-firebase    stable=1.0.1
@generacy-ai/agency-plugin-git         stable=1.0.1
@generacy-ai/agency-plugin-humancy     stable=1.0.1
@generacy-ai/agency-plugin-npm         stable=1.0.1
@generacy-ai/agency-plugin-spec-kit    stable=1.0.1
```

So this PR is just clearing the red CI badge, not unblocking anything.

## Fix

Add `semver` to root `devDependencies`:

```diff
     "eslint": "^9.18.0",
+    "semver": "^7.8.0",
     "turbo": "^2.3.4",
```

Verified locally — `node -e "const s = require('semver'); console.log(s.validRange('^1.0.0'))"` now resolves.

## Test plan

- [ ] PR CI passes
- [ ] After merge through to main, the next Release run gets past `Validate latest peer-dep consistency` cleanly (will be a no-op since no new publish, but the require resolves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)