### PR TITLE
fix: #374 publish claude-plugin-cockpit as @generacy-ai/claude-plugin-cockpit

### DIFF
--- a/.changeset/374-claude-plugin-cockpit-package.md
+++ b/.changeset/374-claude-plugin-cockpit-package.md
@@ -1,0 +1,8 @@
+---
+"@generacy-ai/claude-plugin-cockpit": minor
+---
+
+New package: publish the cockpit Claude Code plugin to npm so cluster setup can
+deliver the `/cockpit:*` commands without the manual marketplace step (#374).
+Ships the six command playbooks, `.claude-plugin/plugin.json`, and README as
+static files — no build step, no runtime code. First release is 0.1.0.

--- a/packages/claude-plugin-cockpit/README.md
+++ b/packages/claude-plugin-cockpit/README.md
@@ -24,6 +24,18 @@ Runtime dependencies (must be on `$PATH` in the session that runs any command):
 - `generacy` CLI (`npm install -g @generacy-ai/cli` or the prevailing install command).
 - `gh` CLI, authenticated with `gh auth login`.
 
+## Distribution
+
+The plugin ships on two rails:
+
+- **Generacy clusters (npm, zero-step).** Cluster setup installs
+  [`@generacy-ai/claude-plugin-cockpit`](https://www.npmjs.com/package/@generacy-ai/claude-plugin-cockpit)
+  from npm — channel-aware (`@preview` / `@stable`, matching the cluster's `GENERACY_CHANNEL`) —
+  and `generacy setup build` copies `commands/` into `~/.claude/commands/cockpit/`, so
+  `/cockpit:*` resolves in a fresh Claude Code session with no manual steps.
+- **Marketplace (standalone).** Outside a cluster, install via the Claude Code marketplace using
+  the steps in [Installation](#installation) above.
+
 ## Available Commands
 
 | Command | Description |
@@ -62,4 +74,4 @@ When the CLI exit code is non-zero (or the pre-flight failed), the command class
 
 ## License
 
-MIT
+Apache-2.0

--- a/packages/claude-plugin-cockpit/package.json
+++ b/packages/claude-plugin-cockpit/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@generacy-ai/claude-plugin-cockpit",
+  "version": "0.0.0",
+  "description": "Claude Code plugin providing /cockpit:* commands for running Generacy speckit epics (watch, status, queue, clarify, review, merge)",
+  "keywords": [
+    "claude-plugin",
+    "cockpit",
+    "generacy",
+    "tetrad",
+    "workflow"
+  ],
+  "author": "Generacy AI",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/agency.git",
+    "directory": "packages/claude-plugin-cockpit"
+  },
+  "files": [
+    "commands",
+    ".claude-plugin",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,8 @@ importers:
         specifier: ^2.8.2
         version: 2.8.2
 
+  packages/claude-plugin-cockpit: {}
+
 packages:
 
   '@azure/abort-controller@2.1.2':


### PR DESCRIPTION
Hand-applied implementation of #374 (epic cockpit A-S2). PR #376 merged with spec artifacts only — the implement phase produced no product changes (see generacy-ai/generacy#820 for the workflow bug).

Implements exactly the recorded clarification answers on #374:

- **Q1 (A):** `version: 0.0.0` + `minor` changeset → first publish is 0.1.0.
- **Q2 (B):** no `agency` metadata block — identity lives in `.claude-plugin/plugin.json`.
- **Q3 (A):** no `type`/`main`/`exports`/`bin`/`scripts` — static markdown only; `publish-preview`'s `--if-present` build skips it cleanly.
- **Q4 (A):** README gains a **Distribution** section covering the npm rail (channel-aware cluster install + `generacy setup build` wiring into `~/.claude/commands/cockpit/`) while keeping the marketplace rail for standalone users. `commands/*.md` untouched.
- **Q5 (A, amended description):** metadata mirrors the spec-kit sibling (author `Generacy AI`, `Apache-2.0`, repository with `directory` subpath). Also fixes the README license footer (MIT → Apache-2.0) to match the repo LICENSE.

Verified: `pnpm pack` tarball contains the six `commands/*.md`, `.claude-plugin/plugin.json`, README, package.json, and the auto-included LICENSE. Lockfile updated for the new workspace package.

After merge, the next develop push auto-publishes `@generacy-ai/claude-plugin-cockpit@preview`, which unblocks the cluster-base#69 install path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)