### PR TITLE
chore: release cockpit plugin to stable

### DIFF
--- a/.changeset/374-claude-plugin-cockpit-package.md
+++ b/.changeset/374-claude-plugin-cockpit-package.md
@@ -1,8 +1,0 @@
----
-"@generacy-ai/claude-plugin-cockpit": minor
----
-
-New package: publish the cockpit Claude Code plugin to npm so cluster setup can
-deliver the `/cockpit:*` commands without the manual marketplace step (#374).
-Ships the six command playbooks, `.claude-plugin/plugin.json`, and README as
-static files — no build step, no runtime code. First release is 0.1.0.

--- a/packages/claude-plugin-cockpit/CHANGELOG.md
+++ b/packages/claude-plugin-cockpit/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @generacy-ai/claude-plugin-cockpit
+
+## 0.1.0
+
+### Minor Changes
+
+- c0548f6: New package: publish the cockpit Claude Code plugin to npm so cluster setup can
+  deliver the `/cockpit:*` commands without the manual marketplace step (#374).
+  Ships the six command playbooks, `.claude-plugin/plugin.json`, and README as
+  static files — no build step, no runtime code. First release is 0.1.0.

--- a/packages/claude-plugin-cockpit/package.json
+++ b/packages/claude-plugin-cockpit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@generacy-ai/claude-plugin-cockpit",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Claude Code plugin providing /cockpit:* commands for running Generacy speckit epics (watch, status, queue, clarify, review, merge)",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Promote `@generacy-ai/claude-plugin-cockpit@0.1.0` (and pending develop state) to main to trigger the stable publish (release.yml runs on CI/main). Part of the epic-cockpit production rollout.