### PR TITLE
fix(plugins): stop Agency MCP serving zero tools

### DIFF
--- a/.changeset/fix-agency-mcp-zero-tools.md
+++ b/.changeset/fix-agency-mcp-zero-tools.md
@@ -1,0 +1,15 @@
+---
+"@generacy-ai/agency": patch
+---
+
+fix(plugins): stop the Agency MCP server from coming up healthy with zero tools.
+
+Three independent defects combined so that `claude mcp list` reported `agency: ✔ Connected` while `tools/list` returned `[]` — leaving speckit slash commands with no `spec_kit.*` tools, so they silently fell back to raw bash.
+
+- **Manifest semver rejected the preview channel.** `SEMVER_PATTERN` used `[\w.]` for the prerelease and build identifiers, but `\w` excludes `-`. The published preview/latest dist-tags are `0.0.0-preview-<timestamp>` — valid semver (§9-10), rejected here — so *every* preview-channel plugin failed validation. Both character classes now allow `-`.
+- **Invalid manifests were dropped silently.** `loadFromPath` swallowed validation failures in a bare `catch`, which is what let the semver bug hide behind a healthy connection. Packages matching the plugin name pattern that fail validation now log the reason to stderr.
+- **Discovery was entirely cwd-relative.** Search paths were `<cwd>/node_modules` plus configured `pluginPaths`. In a cluster the server runs inside a checkout of the *target* repo, which does not depend on the plugins, so nothing was ever found. Discovery now also scans the directory holding agency's own sibling packages — `…/node_modules/@generacy-ai` for npm installs, `…/packages` for source builds — which resolves correctly in both flavours without per-repo configuration. Results are deduplicated by plugin id, and the fallback is scanned last so configured paths still win.
+
+Also fixes the mode default that hid tools even once discovery worked: the default config exposed a single `default` mode, but mode-scoped plugins declare named modes (`spec-kit` → `["research","coding"]`, `npm` → `["coding","review"]`), so none of their tools matched. Defaults now cover the built-in mode names and start in `coding`, the only built-in mode named by every mode-scoped first-party plugin.
+
+Verified against the real preview packages and a source build: from an unrelated working directory with no `.agency/config.json`, an npm-installed tree now exposes 11 `spec_kit.*` tools (was 0) and a source build exposes all 49 (was 0).

--- a/packages/agency/src/config/loader.test.ts
+++ b/packages/agency/src/config/loader.test.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ConfigLoader } from './loader.js';
+import { DEFAULT_MODE, DEFAULT_MODE_PATTERNS } from './schema.js';
 import { AgencyError, ErrorCodes } from '../errors/index.js';
 
 describe('ConfigLoader', () => {
@@ -148,8 +149,18 @@ describe('ConfigLoader', () => {
 
       expect(config.name).toBe('agency');
       expect(config.plugins).toEqual([]);
-      expect(config.modes).toEqual({ default: ['*'] });
-      expect(config.defaultMode).toBe('default');
+      expect(config.modes).toEqual(DEFAULT_MODE_PATTERNS);
+      expect(config.defaultMode).toBe(DEFAULT_MODE);
+    });
+
+    it('defaults to a mode that mode-scoped plugins actually declare', async () => {
+      // spec-kit declares modes ["research","coding"] and npm declares
+      // ["coding","review"]; a default outside those lists hides their tools.
+      const loader = new ConfigLoader(testDir);
+      const config = await loader.load();
+
+      expect(config.defaultMode).toBe('coding');
+      expect(config.modes[config.defaultMode as string]).toEqual(['*']);
     });
   });
 

--- a/packages/agency/src/config/schema.ts
+++ b/packages/agency/src/config/schema.ts
@@ -20,6 +20,33 @@ export {
 } from '../modes/types.js';
 
 /**
+ * Default mode → tool-pattern map.
+ *
+ * Plugins may restrict themselves to named modes via their manifest `modes`
+ * field (spec-kit declares `["research","coding"]`, npm declares
+ * `["coding","review"]`). The previous default exposed a single `default` mode,
+ * which matched none of those names — so an unconfigured server silently
+ * dropped every mode-scoped plugin's tools while still reporting a healthy
+ * connection. Covering the built-in mode names keeps first-party plugins usable
+ * without a per-repo `.agency/config.json`.
+ */
+export const DEFAULT_MODE_PATTERNS: Record<string, string[]> = {
+  default: ['*'],
+  research: ['*'],
+  coding: ['*'],
+  review: ['*'],
+  debug: ['*'],
+};
+
+/**
+ * Mode assumed when a project does not pick one.
+ *
+ * `coding` is the only built-in mode named by every mode-scoped first-party
+ * plugin, so it is the default that exposes the most tools.
+ */
+export const DEFAULT_MODE = 'coding';
+
+/**
  * Schema for plugin-specific configuration
  */
 export const PluginConfigSchema = z.object({
@@ -52,7 +79,7 @@ export const AgencyConfigSchema = z.object({
   /** Mode definitions mapping mode name to tool patterns */
   modes: z
     .record(z.array(z.string()))
-    .default({ default: ['*'] }),
+    .default(() => ({ ...DEFAULT_MODE_PATTERNS })),
 
   /** Default mode to use on startup */
   defaultMode: z.string().optional(),
@@ -95,6 +122,6 @@ export const DEFAULT_CONFIG: AgencyConfig = {
   plugins: [],
   pluginPaths: [],
   pluginOptions: {},
-  modes: { default: ['*'] },
-  defaultMode: 'default',
+  modes: { ...DEFAULT_MODE_PATTERNS },
+  defaultMode: DEFAULT_MODE,
 };

--- a/packages/agency/src/plugins/discovery.test.ts
+++ b/packages/agency/src/plugins/discovery.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { mkdir, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { PluginDiscovery, findNodeModules, createDiscoveryOptions } from './discovery.js';
+import {
+  PluginDiscovery,
+  findNodeModules,
+  createDiscoveryOptions,
+  resolveSiblingPackagesDir,
+} from './discovery.js';
 
 describe('PluginDiscovery', () => {
   let testDir: string;
@@ -56,6 +61,35 @@ describe('PluginDiscovery', () => {
       expect(plugins).toHaveLength(1);
       expect(plugins[0]?.manifest.id).toBe('@generacy-ai/agency-plugin-test');
       expect(plugins[0]?.source).toBe('node_modules');
+    });
+
+    it('discovers preview-channel plugins whose version contains hyphens', async () => {
+      // Regression: `0.0.0-preview-<timestamp>` failed manifest validation, so
+      // every preview-channel plugin was dropped and the MCP server came up
+      // healthy with zero tools.
+      const nodeModules = join(testDir, 'node_modules');
+      await createMockPlugin(nodeModules, '@generacy-ai/agency-plugin-preview', {
+        version: '0.0.0-preview-20260722182217',
+      });
+
+      const plugins = await discovery.discoverFromNodeModules(nodeModules);
+
+      expect(plugins).toHaveLength(1);
+      expect(plugins[0]?.manifest.version).toBe('0.0.0-preview-20260722182217');
+    });
+
+    it('deduplicates a plugin found under more than one search path', async () => {
+      const nodeModules = join(testDir, 'node_modules');
+      await createMockPlugin(nodeModules, '@generacy-ai/agency-plugin-dup', {
+        version: '1.0.0',
+      });
+
+      const plugins = await discovery.discover({
+        searchPaths: [nodeModules, nodeModules],
+        pattern: /^(@generacy-ai\/)?agency-plugin-[\w-]+$/,
+      });
+
+      expect(plugins).toHaveLength(1);
     });
 
     it('discovers multiple plugins', async () => {
@@ -258,15 +292,42 @@ describe('createDiscoveryOptions', () => {
   it('creates options with node_modules path', () => {
     const options = createDiscoveryOptions('/project');
 
-    expect(options.searchPaths).toEqual(['/project/node_modules']);
+    expect(options.searchPaths[0]).toBe('/project/node_modules');
     expect(options.additionalPlugins).toBeUndefined();
   });
 
   it('includes additional plugins when provided', () => {
     const options = createDiscoveryOptions('/project', undefined, ['/custom/plugin1', '/custom/plugin2']);
 
-    expect(options.searchPaths).toEqual(['/project/node_modules']);
+    expect(options.searchPaths[0]).toBe('/project/node_modules');
     expect(options.additionalPlugins).toEqual(['/custom/plugin1', '/custom/plugin2']);
+  });
+
+  it("appends agency's own sibling package directory as a fallback", () => {
+    // Without this the server finds nothing when launched from a repo that
+    // does not itself depend on the plugins — the normal cluster case.
+    const options = createDiscoveryOptions('/project');
+    const siblingDir = resolveSiblingPackagesDir();
+
+    expect(siblingDir).not.toBeNull();
+    expect(options.searchPaths).toContain(siblingDir as string);
+    // Listed last so configured paths win on duplicate plugin ids.
+    expect(options.searchPaths[options.searchPaths.length - 1]).toBe(siblingDir);
+  });
+
+  it('does not duplicate the sibling directory when already configured', () => {
+    const siblingDir = resolveSiblingPackagesDir() as string;
+    const options = createDiscoveryOptions('/project', [siblingDir]);
+
+    expect(options.searchPaths.filter((p) => p === siblingDir)).toHaveLength(1);
+  });
+
+  it('resolves the sibling directory to the parent of the agency package', () => {
+    // npm:    <root>/node_modules/@generacy-ai/agency -> <root>/node_modules/@generacy-ai
+    // source: <root>/packages/agency                  -> <root>/packages
+    const siblingDir = resolveSiblingPackagesDir() as string;
+
+    expect(siblingDir.endsWith('/packages') || siblingDir.endsWith('/@generacy-ai')).toBe(true);
   });
 });
 

--- a/packages/agency/src/plugins/discovery.ts
+++ b/packages/agency/src/plugins/discovery.ts
@@ -6,9 +6,10 @@
  */
 
 import { readdir, readFile, stat } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { DiscoveredPlugin, DiscoveryOptions, PluginManifest } from './types.js';
-import { safeParseManifest } from './manifest.js';
+import { safeParseManifest, validateManifest } from './manifest.js';
 
 /**
  * Default plugin name pattern for node_modules scanning
@@ -20,6 +21,34 @@ const DEFAULT_PLUGIN_PATTERN = /^(@generacy-ai\/)?agency-plugin-[\w-]+$/;
  * Agency manifest field name in package.json
  */
 const AGENCY_MANIFEST_FIELD = 'agency';
+
+/**
+ * Directory that holds the agency package's sibling packages.
+ *
+ * Plugin discovery is otherwise entirely cwd-relative, which breaks whenever
+ * the MCP server is launched from a repo that does not itself depend on the
+ * plugins — the normal case for a cluster, where the server runs inside a
+ * checkout of the *target* repo. Agency's own siblings are a reliable anchor
+ * in every deployment flavour we ship:
+ *
+ *   npm install  → /…/node_modules/@generacy-ai/agency  → …/@generacy-ai
+ *   source build → /…/agency/packages/agency            → …/packages
+ *
+ * In both cases the parent directory contains the `agency-plugin-*` packages,
+ * so scanning it makes first-party plugins discoverable without per-repo
+ * configuration. Returns null when the location cannot be resolved (e.g. a
+ * bundled build with a rewritten import.meta.url).
+ */
+export function resolveSiblingPackagesDir(): string | null {
+  try {
+    // this file lives at <pkgRoot>/dist/plugins/discovery.js (or src/ in dev),
+    // so <pkgRoot> is three levels up and its parent holds the siblings.
+    const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+    return dirname(packageRoot);
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Plugin Discovery class for finding plugins in the filesystem
@@ -39,11 +68,23 @@ export class PluginDiscovery {
    */
   async discover(options: DiscoveryOptions): Promise<DiscoveredPlugin[]> {
     const discovered: DiscoveredPlugin[] = [];
+    // Search paths legitimately overlap (a project's node_modules and agency's
+    // sibling directory can resolve to the same place), so first match wins.
+    const seen = new Set<string>();
+
+    const add = (plugins: DiscoveredPlugin[]): void => {
+      for (const plugin of plugins) {
+        if (seen.has(plugin.manifest.id)) {
+          continue;
+        }
+        seen.add(plugin.manifest.id);
+        discovered.push(plugin);
+      }
+    };
 
     // Scan search paths (typically node_modules directories)
     for (const searchPath of options.searchPaths) {
-      const fromPath = await this.scanPath(searchPath, 'node_modules');
-      discovered.push(...fromPath);
+      add(await this.scanPath(searchPath, 'node_modules'));
     }
 
     // Load additional explicit plugin paths
@@ -51,7 +92,7 @@ export class PluginDiscovery {
       for (const pluginPath of options.additionalPlugins) {
         const plugin = await this.loadFromPath(pluginPath, 'explicit');
         if (plugin) {
-          discovered.push(plugin);
+          add([plugin]);
         }
       }
     }
@@ -163,6 +204,20 @@ export class PluginDiscovery {
 
       const manifest = this.extractManifest(packageJson, packagePath);
       if (!manifest) {
+        // A package that matched the plugin name pattern but failed manifest
+        // validation is almost always a defect, not a package we should ignore.
+        // Swallowing it silently is what let an over-strict semver check hide a
+        // zero-tool MCP server behind a healthy-looking connection.
+        const { errors } = validateManifest({
+          id: packageJson['name'],
+          name: packageJson['name'],
+          version: packageJson['version'],
+          main: packageJson['main'] ?? './dist/index.js',
+        });
+        const reasons = (errors ?? []).map((e) => `${e.path}: ${e.message}`).join('; ');
+        process.stderr.write(
+          `[agency] Ignoring plugin at ${packagePath}: invalid manifest (${reasons || 'unknown reason'})\n`,
+        );
         return null;
       }
 
@@ -263,6 +318,14 @@ export function createDiscoveryOptions(
   // Add additional search paths if provided
   if (additionalSearchPaths) {
     searchPaths.push(...additionalSearchPaths);
+  }
+
+  // Always fall back to agency's own siblings so first-party plugins are found
+  // when the server runs outside a project that depends on them. Listed last so
+  // an explicitly configured path still wins on duplicate plugin ids.
+  const siblingDir = resolveSiblingPackagesDir();
+  if (siblingDir && !searchPaths.includes(siblingDir)) {
+    searchPaths.push(siblingDir);
   }
 
   return {

--- a/packages/agency/src/plugins/manifest.test.ts
+++ b/packages/agency/src/plugins/manifest.test.ts
@@ -51,7 +51,20 @@ describe('PluginManifestSchema', () => {
     });
 
     it('accepts various valid semver versions', () => {
-      const versions = ['0.0.1', '1.0.0', '10.20.30', '1.0.0-alpha', '1.0.0-beta.1', '1.0.0+build.123'];
+      const versions = [
+        '0.0.1',
+        '1.0.0',
+        '10.20.30',
+        '1.0.0-alpha',
+        '1.0.0-beta.1',
+        '1.0.0+build.123',
+        // Hyphens are legal inside prerelease/build identifiers (semver §9-10).
+        // The published preview channel uses exactly this shape; rejecting it
+        // made every preview-channel plugin silently undiscoverable.
+        '0.0.0-preview-20260722182217',
+        '1.2.3-rc-1',
+        '1.0.0+build-123',
+      ];
 
       for (const version of versions) {
         const manifest = {

--- a/packages/agency/src/plugins/manifest.ts
+++ b/packages/agency/src/plugins/manifest.ts
@@ -10,9 +10,15 @@ import type { PluginManifest, ValidationResult } from './types.js';
 
 /**
  * Semver version pattern (simplified)
- * Matches: 1.0.0, 1.2.3-alpha, 1.0.0-beta.1, 1.0.0+build.123
+ * Matches: 1.0.0, 1.2.3-alpha, 1.0.0-beta.1, 1.0.0+build.123,
+ * 0.0.0-preview-20260722182217
+ *
+ * Prerelease and build identifiers may contain hyphens (semver 2.0.0 §9-10),
+ * so the character classes must include `-` and not just `\w`. The published
+ * preview channel uses `0.0.0-preview-<timestamp>`; rejecting it here made
+ * every preview-channel plugin silently undiscoverable.
  */
-const SEMVER_PATTERN = /^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/;
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+(-[\w.-]+)?(\+[\w.-]+)?$/;
 
 /**
  * Plugin ID pattern (npm package format)


### PR DESCRIPTION
## Problem

The Agency MCP server has been coming up **healthy but empty**: `claude mcp list` reports `agency: ✔ Connected` while `tools/list` returns `[]`. With no `spec_kit.*` tools available, the speckit slash commands silently fall back to raw bash — with nothing in any log to say why.

Three independent defects combine to produce it.

### 1. Manifest semver rejected the entire preview channel

```js
const SEMVER_PATTERN = /^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/;
```

`\w` is `[A-Za-z0-9_]` — no hyphen. The published dist-tags are `0.0.0-preview-<timestamp>`, which is valid semver (§9-10 allow hyphens in prerelease/build identifiers) but fails here at the hyphen inside the prerelease. `preview` **and** `latest` are affected; only `stable` (`1.0.1`) passed. Every preview-channel cluster therefore loaded zero plugins.

### 2. Invalid manifests were dropped silently

`loadFromPath` swallowed validation failures in a bare `catch`. That is what let defect 1 hide behind a healthy connection for so long. Rejected packages now log the reason to stderr.

### 3. Discovery was entirely cwd-relative

Search paths were `<cwd>/node_modules` plus configured `pluginPaths`. In a cluster the server runs inside a checkout of the **target** repo, which does not depend on the agency plugins, so nothing was ever found — regardless of semver.

Discovery now also scans the directory holding agency's own siblings, which resolves in both deployment flavours:

| flavour | agency package | sibling dir scanned |
|---|---|---|
| npm install | `…/node_modules/@generacy-ai/agency` | `…/node_modules/@generacy-ai` |
| source build | `…/agency/packages/agency` | `…/agency/packages` |

Results are deduplicated by plugin id, and the fallback is scanned last so configured paths still win.

### Bonus: mode defaults hid tools even once discovery worked

`DEFAULT_CONFIG` exposed a single `default` mode, but mode-scoped plugins declare *named* modes — spec-kit `["research","coding"]`, npm `["coding","review"]` — so none of their tools matched. Defaults now cover the built-in mode names and start in `coding`, the only built-in mode named by every mode-scoped first-party plugin.

## Verification

Probed over real stdio against the actual published preview packages and a source build, from an unrelated working directory with **no** `.agency/config.json`:

| tree | before | after |
|---|---|---|
| npm preview packages | 0 tools | **11** `spec_kit.*` |
| source build | 0 tools | **49** (incl. 11 `spec_kit.*`) |

Test suite: 1524 passed. New coverage for the preview-version regression, sibling-path resolution, search-path dedup, and the mode default.

## Reviewer notes

- The mode default change is the one behavioural judgement call here. An unconfigured server previously exposed nothing at all, which seems clearly unintended; repos with an explicit `.agency/config.json` are unaffected.
- Invalid-version rejection still works — `1`, `1.0`, `v1.0.0`, `invalid`, `''` all still fail.
- Ships with a patch changeset. Preview clusters need a preview release before they pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)