### PR TITLE
fix(ci): stop preview publish from burning real package versions

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -27,27 +27,46 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Every publishable package must be named by SOME changeset before
+      # `changeset version --snapshot` runs. A package left uncovered keeps its
+      # real package.json version, and `changeset publish --tag preview` then
+      # publishes that real version under @preview — permanently burning the
+      # version number, because npm forbids republishing it and the stable
+      # Release job will skip it as "already published" forever after. That is
+      # how @generacy-ai/claude-plugin-cockpit@0.1.1 shipped under @preview on
+      # 2026-08-07, stranding @stable on 0.1.0. Topping up the uncovered
+      # packages (rather than only synthesizing when .changeset is empty) is
+      # what closes the partial-coverage hole.
       - name: Ensure changesets for preview
         run: |
-          CHANGESET_FILES=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | head -1)
-          if [ -n "$CHANGESET_FILES" ]; then
-            echo "Changeset files found, proceeding with preview publish"
-          else
-            echo "No changeset files found, generating synthetic changeset"
-            node -e "
-              const fs = require('fs'), path = require('path');
-              const config = JSON.parse(fs.readFileSync('.changeset/config.json', 'utf8'));
-              const ignore = new Set(config.ignore || []);
-              const pkgs = fs.readdirSync('packages')
-                .map(d => path.join('packages', d, 'package.json'))
-                .filter(p => fs.existsSync(p))
-                .map(p => JSON.parse(fs.readFileSync(p, 'utf8')))
-                .filter(p => !p.private && p.name && !ignore.has(p.name));
-              const lines = ['---', ...pkgs.map(p => '\"' + p.name + '\": patch'), '---', '', 'Preview publish (synthetic)', ''];
-              fs.writeFileSync('.changeset/preview-publish.md', lines.join('\n'));
-              console.log('Created synthetic changeset for ' + pkgs.length + ' packages');
-            "
-          fi
+          node - <<'EOF'
+          const fs = require('fs'), path = require('path');
+          const config = JSON.parse(fs.readFileSync('.changeset/config.json', 'utf8'));
+          const ignore = new Set(config.ignore || []);
+          const pkgs = fs.readdirSync('packages')
+            .map(d => path.join('packages', d, 'package.json'))
+            .filter(p => fs.existsSync(p))
+            .map(p => JSON.parse(fs.readFileSync(p, 'utf8')))
+            .filter(p => !p.private && p.name && !ignore.has(p.name));
+
+          // Package names already declared in the frontmatter of a pending changeset.
+          const covered = new Set();
+          for (const entry of fs.readdirSync('.changeset')) {
+            if (!entry.endsWith('.md') || entry === 'README.md') continue;
+            const src = fs.readFileSync(path.join('.changeset', entry), 'utf8');
+            const frontmatter = src.split(/^---$/m)[1] || '';
+            for (const m of frontmatter.matchAll(/"([^"]+)"\s*:/g)) covered.add(m[1]);
+          }
+
+          const missing = pkgs.filter((p) => !covered.has(p.name));
+          if (missing.length === 0) {
+            console.log(`All ${pkgs.length} publishable packages are covered by pending changesets`);
+            process.exit(0);
+          }
+          const lines = ['---', ...missing.map((p) => `"${p.name}": patch`), '---', '', 'Preview publish (synthetic)', ''];
+          fs.writeFileSync('.changeset/preview-publish.md', lines.join('\n'));
+          console.log(`Created synthetic changeset topping up ${missing.length} uncovered package(s): ${missing.map((p) => p.name).join(', ')}`);
+          EOF
 
       - name: Verify latency dependency
         id: latency
@@ -80,11 +99,40 @@ jobs:
         if: steps.latency.outputs.found == 'true'
         run: pnpm build
 
-      - name: Publish preview snapshots
+      - name: Version preview snapshots
+        if: steps.latency.outputs.found == 'true'
+        run: pnpm changeset version --snapshot preview
+
+      # Backstop for the failure mode described above: refuse to publish if any
+      # publishable package still carries a real (non-snapshot) version. Failing
+      # red here is always recoverable; publishing a real version under @preview
+      # is not.
+      - name: Assert all versions are preview snapshots
         if: steps.latency.outputs.found == 'true'
         run: |
-          pnpm changeset version --snapshot preview
-          pnpm changeset publish --tag preview --provenance
+          node - <<'EOF'
+          const fs = require('fs'), path = require('path');
+          const config = JSON.parse(fs.readFileSync('.changeset/config.json', 'utf8'));
+          const ignore = new Set(config.ignore || []);
+          const offenders = fs.readdirSync('packages')
+            .map(d => path.join('packages', d, 'package.json'))
+            .filter(p => fs.existsSync(p))
+            .map(p => JSON.parse(fs.readFileSync(p, 'utf8')))
+            .filter(p => !p.private && p.name && !ignore.has(p.name))
+            .filter(p => !/^0\.0\.0-preview-/.test(p.version));
+
+          if (offenders.length > 0) {
+            for (const p of offenders) {
+              console.log(`::error::${p.name}@${p.version} is not a preview snapshot — publishing it under @preview would burn that version number and permanently strand @stable. Add a changeset for ${p.name}.`);
+            }
+            process.exit(1);
+          }
+          console.log('All publishable packages carry 0.0.0-preview-* versions.');
+          EOF
+
+      - name: Publish preview snapshots
+        if: steps.latency.outputs.found == 'true'
+        run: pnpm changeset publish --tag preview --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

`publish-preview.yml` only synthesized a changeset when `.changeset` was **completely empty**. With a *partial* set of pending changesets, any package not named by one kept its real `package.json` version through `changeset version --snapshot preview` — and `changeset publish --tag preview` then published that **real version under the `@preview` tag**.

This is unrecoverable. npm forbids republishing a version, so the stable Release job skips the package forever after as "already published", and its `@stable` tag can never advance to it.

### It already happened

On 2026-08-07 at 16:33:30Z, Publish Preview [run 31198147359](https://github.com/generacy-ai/agency/actions/runs/31198147359) logged `Changeset files found, proceeding with preview publish` — the partial-coverage path. The pending changesets covered `@generacy-ai/agency` and its 6 plugins (all correctly versioned `0.0.0-preview-20260807163406`), but not `@generacy-ai/claude-plugin-cockpit`:

```
info @generacy-ai/claude-plugin-cockpit is being published because our local version (0.1.1) has not been published on npm
info Publishing "@generacy-ai/claude-plugin-cockpit" at "0.1.1"
```

The Release run 6 minutes later (`changeset publish --tag stable`) skipped it as already-published. Result, still true today:

| tag | version | published |
|---|---|---|
| `stable` | 0.1.0 | 2026-07-13 |
| `latest` | `0.0.0-preview-20260707012347` | 2026-07-07 |
| `preview` | current snapshot | — |

Nothing points at 0.1.1, and no future release can fix it via `changeset publish`.

**Downstream impact:** clusters install the plugin as `@generacy-ai/claude-plugin-cockpit@${CHANNEL}` (`entrypoint-orchestrator.sh`, `setup-speckit.sh`), so every `stable`-channel cluster silently kept the 0.1.0 command set — `auto.md` at 92,939 bytes with zero `--gates=ui` support, vs 370,394 bytes in 0.1.1. A cluster restart faithfully reinstalls 0.1.0, so the symptom looks like a cluster bug rather than a release bug.

## Changes

- **Ensure changesets for preview** now tops up the packages that no pending changeset names, instead of only acting when `.changeset` is bare. Every publishable package is covered before versioning, so `--snapshot` rewrites them all.
- **New assert step** between versioning and publishing refuses to publish if any publishable package still carries a non-snapshot version. Failing red is recoverable; publishing a real version under `@preview` is not.

## Verification

Both scripts were extracted from the workflow and executed against a mirror of the real `packages/*/package.json` set:

| case | expected | result |
|---|---|---|
| No pending changesets | top up all 8 | ✅ 8 packages, matches old behavior |
| **Only `@generacy-ai/agency` covered (reproduces 2026-08-07)** | top up 7 incl. `claude-plugin-cockpit` | ✅ leak closed |
| All 8 already covered | write nothing | ✅ no redundant file |
| Assert with real versions | fail red, name offenders | ✅ exit 1 |
| Assert with all snapshots | pass | ✅ exit 0 |
| Assert with only `claude-plugin-cockpit` at 0.1.1 | fail red, name it | ✅ exit 1 |

YAML parses; step order is Version → Assert → Publish.

## Not fixed here

The stranded tags need a manual `npm dist-tag add` — this PR only prevents recurrence:

```bash
npm dist-tag add @generacy-ai/claude-plugin-cockpit@0.1.1 stable
npm dist-tag add @generacy-ai/claude-plugin-cockpit@0.1.1 latest
```

Content-safe: published 0.1.1 is **byte-identical** to `main` across all seven command files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)