### PR TITLE
fix(npm): cap failure output, merge streams, add exec timeout in build/test tools

### DIFF
--- a/.changeset/npm-tool-failure-output-caps.md
+++ b/.changeset/npm-tool-failure-output-caps.md
@@ -1,0 +1,10 @@
+---
+"@generacy-ai/agency-plugin-npm": patch
+---
+
+fix(npm): cap failure output, stop stream masking, and bound execution time in the build/test tools.
+
+- Failure paths previously embedded one raw stream whole (`stderr || stdout` for build tools, `stdout || stderr` for test tools) with no size limit — a failing test suite could return an unbounded log (a real hazard for agent context windows), and a single warning line on one stream hid the actual error on the other. Failures now return both streams labeled, clamped to the last 200 lines / 8 KB with an explicit truncation marker (`formatFailureOutput` in `src/exec/output.ts`). Success output is unchanged (terse).
+- `exec` never set a timeout, so a hung script stalled the MCP call forever. A 10-minute default now applies, with a note appended when the process is killed by a signal.
+- Removed the `watch` parameter from the `test.run_*` schemas — `--watch` never exits, which guaranteed a hang.
+- `test.run_coverage` now reads the "All files" row of the coverage summary instead of the first percentage anywhere in stdout, which could match an unrelated number.

--- a/packages/agency-plugin-npm/src/exec/index.ts
+++ b/packages/agency-plugin-npm/src/exec/index.ts
@@ -3,4 +3,11 @@
  */
 
 export type { ExecResult, ExecOptions } from './runner.js';
-export { exec, formatCommand } from './runner.js';
+export { exec, formatCommand, DEFAULT_EXEC_TIMEOUT_MS } from './runner.js';
+export {
+  combineStreams,
+  clampTail,
+  formatFailureOutput,
+  MAX_FAILURE_LINES,
+  MAX_FAILURE_CHARS,
+} from './output.js';

--- a/packages/agency-plugin-npm/src/exec/output.ts
+++ b/packages/agency-plugin-npm/src/exec/output.ts
@@ -1,0 +1,64 @@
+/**
+ * Failure-output shaping.
+ *
+ * Success paths return terse fixed messages; failure paths embed the captured
+ * stream. Cap that stream so a large build/test log cannot blow out the
+ * caller's context window: keep the tail, which is where compilers and test
+ * runners put their error summaries.
+ */
+
+import type { ExecResult } from './runner.js';
+
+/** Maximum number of lines of failure output to return */
+export const MAX_FAILURE_LINES = 200;
+
+/** Maximum characters of failure output to return */
+export const MAX_FAILURE_CHARS = 8_192;
+
+/**
+ * Merge stdout and stderr into one block.
+ *
+ * Tools historically returned `stderr || stdout`, which let a single warning
+ * line on one stream hide the actual error on the other. Returning both,
+ * labeled, avoids that masking.
+ */
+export function combineStreams(result: Pick<ExecResult, 'stdout' | 'stderr'>): string {
+  const stdout = result.stdout.trim();
+  const stderr = result.stderr.trim();
+
+  if (stdout && stderr) {
+    return `${stdout}\n--- stderr ---\n${stderr}`;
+  }
+  return stdout || stderr || '(no output)';
+}
+
+/**
+ * Keep only the tail of a block of text, bounded by lines and characters.
+ * A truncation marker is prepended when anything was dropped.
+ */
+export function clampTail(
+  text: string,
+  maxLines: number = MAX_FAILURE_LINES,
+  maxChars: number = MAX_FAILURE_CHARS
+): string {
+  const lines = text.split('\n');
+  const kept = lines.length > maxLines ? lines.slice(lines.length - maxLines) : lines;
+  let joined = kept.join('\n');
+
+  if (joined.length > maxChars) {
+    joined = joined.slice(joined.length - maxChars);
+  }
+
+  if (joined.length < text.length) {
+    const dropped = text.length - joined.length;
+    return `… [output truncated: ${dropped} earlier characters dropped, showing tail] …\n${joined}`;
+  }
+  return text;
+}
+
+/**
+ * Standard failure-output body: both streams, tail-clamped.
+ */
+export function formatFailureOutput(result: Pick<ExecResult, 'stdout' | 'stderr'>): string {
+  return clampTail(combineStreams(result));
+}

--- a/packages/agency-plugin-npm/src/exec/runner.ts
+++ b/packages/agency-plugin-npm/src/exec/runner.ts
@@ -35,6 +35,13 @@ export interface ExecOptions {
 }
 
 /**
+ * Default timeout applied when the caller does not set one. Package scripts
+ * (builds, test suites) that run longer than this are killed rather than
+ * hanging the MCP call forever.
+ */
+export const DEFAULT_EXEC_TIMEOUT_MS = 600_000;
+
+/**
  * Execute a command and capture output
  *
  * @param command - Command to execute
@@ -47,6 +54,8 @@ export async function exec(
   args: string[],
   options: ExecOptions
 ): Promise<ExecResult> {
+  const timeoutMs = options.timeout ?? DEFAULT_EXEC_TIMEOUT_MS;
+
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       cwd: options.cwd,
@@ -55,7 +64,7 @@ export async function exec(
         ...options.env,
       },
       shell: true,
-      timeout: options.timeout,
+      timeout: timeoutMs,
     });
 
     const stdout: string[] = [];
@@ -78,11 +87,17 @@ export async function exec(
       });
     });
 
-    child.on('close', (code) => {
+    child.on('close', (code, signal) => {
+      // A null exit code with a signal means the process was killed — with
+      // shell: true the most likely cause is our own timeout SIGTERM.
+      const signalNote =
+        code === null && signal
+          ? `\nProcess terminated by ${signal} — the command may have exceeded the ${timeoutMs}ms timeout.`
+          : '';
       resolve({
         exitCode: code ?? 1,
         stdout: stdout.join(''),
-        stderr: stderr.join(''),
+        stderr: stderr.join('') + signalNote,
         shortMessage: options.shortMessage,
       });
     });

--- a/packages/agency-plugin-npm/src/tools/build/compile.ts
+++ b/packages/agency-plugin-npm/src/tools/build/compile.ts
@@ -7,7 +7,7 @@ import { TerseOutput, terseToMcpToolResult } from '@generacy-ai/agency';
 import { CompileSchema, zodToJsonSchema } from '../schemas.js';
 import { detectPackageManager, isDetectionSuccess, buildCommand } from '../../pm/index.js';
 import { validateScript, formatScriptNotFoundError } from '../../scripts/index.js';
-import { exec, formatCommand } from '../../exec/index.js';
+import { exec, formatCommand, formatFailureOutput } from '../../exec/index.js';
 import type { NpmPluginConfig } from '../../config.js';
 
 /**
@@ -69,7 +69,7 @@ export function createCompileTool(config: NpmPluginConfig): AgencyTool {
           '',
           `> ${cmdStr}`,
           '',
-          result.stderr || result.stdout,
+          formatFailureOutput(result),
           '',
           'Recovery: Fix the build errors and run again.',
         ].join('\n');

--- a/packages/agency-plugin-npm/src/tools/build/format.ts
+++ b/packages/agency-plugin-npm/src/tools/build/format.ts
@@ -7,7 +7,7 @@ import { TerseOutput, terseToMcpToolResult } from '@generacy-ai/agency';
 import { FormatSchema, zodToJsonSchema } from '../schemas.js';
 import { detectPackageManager, isDetectionSuccess, buildCommand } from '../../pm/index.js';
 import { validateScript, formatScriptNotFoundError } from '../../scripts/index.js';
-import { exec, formatCommand } from '../../exec/index.js';
+import { exec, formatCommand, formatFailureOutput } from '../../exec/index.js';
 import type { NpmPluginConfig } from '../../config.js';
 
 /**
@@ -76,7 +76,7 @@ export function createFormatTool(config: NpmPluginConfig): AgencyTool {
           '',
           `> ${cmdStr}`,
           '',
-          result.stderr || result.stdout,
+          formatFailureOutput(result),
           '',
           check
             ? 'Recovery: Run without check=true to apply formatting.'

--- a/packages/agency-plugin-npm/src/tools/build/install-dependencies.ts
+++ b/packages/agency-plugin-npm/src/tools/build/install-dependencies.ts
@@ -6,7 +6,7 @@ import type { AgencyTool, ToolResult } from '@generacy-ai/agency';
 import { TerseOutput, terseToMcpToolResult } from '@generacy-ai/agency';
 import { InstallDependenciesSchema, zodToJsonSchema } from '../schemas.js';
 import { detectPackageManager, isDetectionSuccess, buildCommand } from '../../pm/index.js';
-import { exec, formatCommand } from '../../exec/index.js';
+import { exec, formatCommand, formatFailureOutput } from '../../exec/index.js';
 import type { NpmPluginConfig } from '../../config.js';
 
 /**
@@ -61,7 +61,7 @@ export function createInstallDependenciesTool(config: NpmPluginConfig): AgencyTo
           '',
           `> ${cmdStr}`,
           '',
-          result.stderr || result.stdout,
+          formatFailureOutput(result),
           '',
           'Recovery: Check network connectivity and package availability.',
         ].join('\n');

--- a/packages/agency-plugin-npm/src/tools/build/lint.ts
+++ b/packages/agency-plugin-npm/src/tools/build/lint.ts
@@ -7,7 +7,7 @@ import { TerseOutput, terseToMcpToolResult } from '@generacy-ai/agency';
 import { LintSchema, zodToJsonSchema } from '../schemas.js';
 import { detectPackageManager, isDetectionSuccess, buildCommand } from '../../pm/index.js';
 import { validateScript, formatScriptNotFoundError } from '../../scripts/index.js';
-import { exec, formatCommand } from '../../exec/index.js';
+import { exec, formatCommand, formatFailureOutput } from '../../exec/index.js';
 import type { NpmPluginConfig } from '../../config.js';
 
 /**
@@ -76,7 +76,7 @@ export function createLintTool(config: NpmPluginConfig): AgencyTool {
           '',
           `> ${cmdStr}`,
           '',
-          result.stderr || result.stdout,
+          formatFailureOutput(result),
           '',
           fix
             ? 'Recovery: Some issues could not be auto-fixed. Fix them manually.'

--- a/packages/agency-plugin-npm/src/tools/build/validate.ts
+++ b/packages/agency-plugin-npm/src/tools/build/validate.ts
@@ -10,7 +10,7 @@ import { TerseOutput, terseToMcpToolResult } from '@generacy-ai/agency';
 import { ValidateSchema, zodToJsonSchema } from '../schemas.js';
 import { detectPackageManager, isDetectionSuccess, buildCommand } from '../../pm/index.js';
 import { getAvailableScripts } from '../../scripts/index.js';
-import { exec } from '../../exec/index.js';
+import { exec, formatFailureOutput } from '../../exec/index.js';
 import type { NpmPluginConfig } from '../../config.js';
 
 /** A script candidate resolved for execution */
@@ -222,7 +222,7 @@ export function createValidateTool(config: NpmPluginConfig): AgencyTool {
       for (const r of failed) {
         lines.push('');
         lines.push(`--- ${r.name} ---`);
-        lines.push(r.stderr || r.stdout);
+        lines.push(formatFailureOutput(r));
       }
 
       lines.push('');

--- a/packages/agency-plugin-npm/src/tools/schemas.ts
+++ b/packages/agency-plugin-npm/src/tools/schemas.ts
@@ -70,9 +70,6 @@ const BaseTestSchema = BaseParamsSchema.extend({
   /** Test file pattern to run */
   pattern: z.string().optional(),
 
-  /** Run in watch mode */
-  watch: z.boolean().optional(),
-
   /** Test script name */
   script: z.string().optional(),
 });

--- a/packages/agency-plugin-npm/src/tools/test/run-coverage.ts
+++ b/packages/agency-plugin-npm/src/tools/test/run-coverage.ts
@@ -7,7 +7,7 @@ import { TerseOutput, terseToMcpToolResult } from '@generacy-ai/agency';
 import { RunCoverageSchema, zodToJsonSchema } from '../schemas.js';
 import { detectPackageManager, isDetectionSuccess, buildCommand } from '../../pm/index.js';
 import { validateScript, formatScriptNotFoundError } from '../../scripts/index.js';
-import { exec, formatCommand } from '../../exec/index.js';
+import { exec, formatCommand, formatFailureOutput } from '../../exec/index.js';
 import type { NpmPluginConfig } from '../../config.js';
 
 /**
@@ -79,7 +79,7 @@ export function createRunCoverageTool(config: NpmPluginConfig): AgencyTool {
           '',
           `> ${cmdStr}`,
           '',
-          result.stdout || result.stderr,
+          formatFailureOutput(result),
           '',
           threshold !== undefined
             ? `Recovery: Increase test coverage to meet ${threshold}% threshold.`
@@ -89,8 +89,13 @@ export function createRunCoverageTool(config: NpmPluginConfig): AgencyTool {
         return terseToMcpToolResult(TerseOutput.failure(output));
       }
 
-      // Extract coverage percentage from output if possible
-      const coverageMatch = result.stdout.match(/(\d+(?:\.\d+)?)\s*%/);
+      // Extract coverage percentage from output if possible. Prefer the
+      // "All files" row of the istanbul/v8 text summary (its first numeric
+      // column is total statement coverage); fall back to the first
+      // percentage anywhere in the output.
+      const coverageMatch =
+        result.stdout.match(/All files[^|\n]*\|\s*(\d+(?:\.\d+)?)/) ??
+        result.stdout.match(/(\d+(?:\.\d+)?)\s*%/);
       const coveragePercent = coverageMatch ? coverageMatch[1] : null;
 
       const successMessage = coveragePercent

--- a/packages/agency-plugin-npm/src/tools/test/run-e2e.ts
+++ b/packages/agency-plugin-npm/src/tools/test/run-e2e.ts
@@ -7,7 +7,7 @@ import { TerseOutput, terseToMcpToolResult } from '@generacy-ai/agency';
 import { RunE2ESchema, zodToJsonSchema } from '../schemas.js';
 import { detectPackageManager, isDetectionSuccess, buildCommand } from '../../pm/index.js';
 import { validateScript, formatScriptNotFoundError } from '../../scripts/index.js';
-import { exec, formatCommand } from '../../exec/index.js';
+import { exec, formatCommand, formatFailureOutput } from '../../exec/index.js';
 import type { NpmPluginConfig } from '../../config.js';
 
 /**
@@ -30,7 +30,7 @@ export function createRunE2ETool(config: NpmPluginConfig): AgencyTool {
         );
       }
 
-      const { cwd = process.cwd(), workspace, pattern, watch } = parsed.data;
+      const { cwd = process.cwd(), workspace, pattern } = parsed.data;
       const scriptName = parsed.data.script ?? config.scripts['test:e2e'] ?? 'test:e2e';
 
       // Validate script exists
@@ -55,9 +55,6 @@ export function createRunE2ETool(config: NpmPluginConfig): AgencyTool {
       if (pattern) {
         additionalArgs.push(pattern);
       }
-      if (watch) {
-        additionalArgs.push('--watch');
-      }
 
       // Build the command
       const { command, args } = buildCommand(pm, 'run', {
@@ -79,7 +76,7 @@ export function createRunE2ETool(config: NpmPluginConfig): AgencyTool {
           '',
           `> ${cmdStr}`,
           '',
-          result.stdout || result.stderr,
+          formatFailureOutput(result),
           '',
           'Recovery: Fix the failing tests and run again.',
         ].join('\n');

--- a/packages/agency-plugin-npm/src/tools/test/run-integration.ts
+++ b/packages/agency-plugin-npm/src/tools/test/run-integration.ts
@@ -7,7 +7,7 @@ import { TerseOutput, terseToMcpToolResult } from '@generacy-ai/agency';
 import { RunIntegrationSchema, zodToJsonSchema } from '../schemas.js';
 import { detectPackageManager, isDetectionSuccess, buildCommand } from '../../pm/index.js';
 import { validateScript, formatScriptNotFoundError } from '../../scripts/index.js';
-import { exec, formatCommand } from '../../exec/index.js';
+import { exec, formatCommand, formatFailureOutput } from '../../exec/index.js';
 import type { NpmPluginConfig } from '../../config.js';
 
 /**
@@ -30,7 +30,7 @@ export function createRunIntegrationTool(config: NpmPluginConfig): AgencyTool {
         );
       }
 
-      const { cwd = process.cwd(), workspace, pattern, watch } = parsed.data;
+      const { cwd = process.cwd(), workspace, pattern } = parsed.data;
       const scriptName = parsed.data.script ?? config.scripts['test:integration'] ?? 'test:integration';
 
       // Validate script exists
@@ -55,9 +55,6 @@ export function createRunIntegrationTool(config: NpmPluginConfig): AgencyTool {
       if (pattern) {
         additionalArgs.push(pattern);
       }
-      if (watch) {
-        additionalArgs.push('--watch');
-      }
 
       // Build the command
       const { command, args } = buildCommand(pm, 'run', {
@@ -79,7 +76,7 @@ export function createRunIntegrationTool(config: NpmPluginConfig): AgencyTool {
           '',
           `> ${cmdStr}`,
           '',
-          result.stdout || result.stderr,
+          formatFailureOutput(result),
           '',
           'Recovery: Fix the failing tests and run again.',
         ].join('\n');

--- a/packages/agency-plugin-npm/src/tools/test/run-unit.ts
+++ b/packages/agency-plugin-npm/src/tools/test/run-unit.ts
@@ -7,7 +7,7 @@ import { TerseOutput, terseToMcpToolResult } from '@generacy-ai/agency';
 import { RunUnitSchema, zodToJsonSchema } from '../schemas.js';
 import { detectPackageManager, isDetectionSuccess, buildCommand } from '../../pm/index.js';
 import { validateScript, formatScriptNotFoundError } from '../../scripts/index.js';
-import { exec, formatCommand } from '../../exec/index.js';
+import { exec, formatCommand, formatFailureOutput } from '../../exec/index.js';
 import type { NpmPluginConfig } from '../../config.js';
 
 /**
@@ -30,7 +30,7 @@ export function createRunUnitTool(config: NpmPluginConfig): AgencyTool {
         );
       }
 
-      const { cwd = process.cwd(), workspace, pattern, watch } = parsed.data;
+      const { cwd = process.cwd(), workspace, pattern } = parsed.data;
       const scriptName = parsed.data.script ?? config.scripts.test ?? 'test';
 
       // Validate script exists
@@ -55,9 +55,6 @@ export function createRunUnitTool(config: NpmPluginConfig): AgencyTool {
       if (pattern) {
         additionalArgs.push(pattern);
       }
-      if (watch) {
-        additionalArgs.push('--watch');
-      }
 
       // Build the command
       const { command, args } = buildCommand(pm, 'run', {
@@ -74,13 +71,13 @@ export function createRunUnitTool(config: NpmPluginConfig): AgencyTool {
 
       if (result.exitCode !== 0) {
         const cmdStr = formatCommand(command, args);
-        // Include full output on test failure
+        // Include the tail of both streams on test failure
         const output = [
           `Tests failed (exit code ${result.exitCode}):`,
           '',
           `> ${cmdStr}`,
           '',
-          result.stdout || result.stderr,
+          formatFailureOutput(result),
           '',
           'Recovery: Fix the failing tests and run again.',
         ].join('\n');

--- a/packages/agency-plugin-npm/tests/exec/output.test.ts
+++ b/packages/agency-plugin-npm/tests/exec/output.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for failure-output shaping
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  combineStreams,
+  clampTail,
+  formatFailureOutput,
+  MAX_FAILURE_CHARS,
+  MAX_FAILURE_LINES,
+} from '../../src/exec/output.js';
+
+describe('combineStreams', () => {
+  it('returns stdout alone when stderr is empty', () => {
+    expect(combineStreams({ stdout: 'out\n', stderr: '' })).toBe('out');
+  });
+
+  it('returns stderr alone when stdout is empty', () => {
+    expect(combineStreams({ stdout: '', stderr: 'err\n' })).toBe('err');
+  });
+
+  it('labels and includes both streams when both are non-empty', () => {
+    const combined = combineStreams({ stdout: 'the real error', stderr: 'one warning' });
+    expect(combined).toContain('the real error');
+    expect(combined).toContain('--- stderr ---');
+    expect(combined).toContain('one warning');
+  });
+
+  it('returns a placeholder when both streams are empty', () => {
+    expect(combineStreams({ stdout: '', stderr: '' })).toBe('(no output)');
+  });
+});
+
+describe('clampTail', () => {
+  it('returns short text unchanged with no marker', () => {
+    expect(clampTail('a\nb\nc')).toBe('a\nb\nc');
+  });
+
+  it('keeps only the last maxLines lines', () => {
+    const text = Array.from({ length: 500 }, (_, i) => `line ${i}`).join('\n');
+    const clamped = clampTail(text);
+    expect(clamped).toContain('[output truncated');
+    expect(clamped).toContain('line 499');
+    expect(clamped).not.toContain('line 0\n');
+  });
+
+  it('caps total characters, keeping the tail', () => {
+    const text = 'x'.repeat(MAX_FAILURE_CHARS * 3) + '\nfinal summary';
+    const clamped = clampTail(text);
+    expect(clamped.length).toBeLessThanOrEqual(MAX_FAILURE_CHARS + 100);
+    expect(clamped).toContain('[output truncated');
+    expect(clamped).toContain('final summary');
+  });
+
+  it('respects explicit limits', () => {
+    const clamped = clampTail('a\nb\nc\nd', 2, 100);
+    expect(clamped).toContain('c\nd');
+    expect(clamped).not.toContain('a\nb');
+  });
+
+  it('exports sane default limits', () => {
+    expect(MAX_FAILURE_LINES).toBeGreaterThan(0);
+    expect(MAX_FAILURE_CHARS).toBeGreaterThan(0);
+  });
+});
+
+describe('formatFailureOutput', () => {
+  it('combines streams then clamps', () => {
+    const stdout = Array.from({ length: 1000 }, (_, i) => `test ${i} failed`).join('\n');
+    const formatted = formatFailureOutput({ stdout, stderr: 'runner exited 1' });
+    expect(formatted).toContain('[output truncated');
+    expect(formatted).toContain('test 999 failed');
+    expect(formatted).toContain('runner exited 1');
+  });
+});

--- a/packages/agency-plugin-npm/tests/tools/build.test.ts
+++ b/packages/agency-plugin-npm/tests/tools/build.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../src/exec/runner.js', () => ({
     shortMessage: 'Operation completed.',
   }),
   formatCommand: (cmd: string, args: string[]) => `${cmd} ${args.join(' ')}`,
+  DEFAULT_EXEC_TIMEOUT_MS: 600_000,
 }));
 
 describe('build tools', () => {

--- a/packages/agency-plugin-npm/tests/tools/test.test.ts
+++ b/packages/agency-plugin-npm/tests/tools/test.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../src/exec/runner.js', () => ({
     shortMessage: 'Tests passed.',
   }),
   formatCommand: (cmd: string, args: string[]) => `${cmd} ${args.join(' ')}`,
+  DEFAULT_EXEC_TIMEOUT_MS: 600_000,
 }));
 
 describe('test tools', () => {


### PR DESCRIPTION
Part 1 of the agency MCP token-efficiency work (tool-output audit).

The nine `build.*` / `test.*` tools are terse on success but had three defects on the failure path:

- **Unbounded failure output.** The raw captured stream was embedded whole in the MCP response — a failing test suite could return hundreds of KB into an agent's context window. Failures are now clamped to the last **200 lines / 8 KB** (tail-first, where compilers and test runners put their summaries) with an explicit truncation marker. New shared helpers live in `src/exec/output.ts`.
- **Stream masking.** Build tools returned `stderr || stdout`, test tools `stdout || stderr` — one warning line on the "wrong" stream hid the stream containing the actual error. Failures now include both streams, labeled.
- **No timeout.** `exec` never set one, so `test.run_unit` with `watch: true` (allowed by the schema) hung the call forever. `exec` now defaults to a **10-minute timeout** and appends a note when the process dies by signal; the `watch` parameter is deleted from the `test.run_*` schemas.

Also fixes `test.run_coverage`'s percentage extraction: it matched the *first* `NN%` anywhere in stdout (not necessarily total coverage); it now prefers the "All files" row of the istanbul/v8 summary and only falls back to the old regex.

Success-path behavior is unchanged (terse fixed messages).

Test plan: `pnpm build && pnpm vitest run` in `packages/agency-plugin-npm` (52 tests, incl. new `tests/exec/output.test.ts`); lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)