### PR TITLE
fix(spec-kit): remove phantom tool calls from playbooks, add implement partial sentinel

### DIFF
--- a/.changeset/speckit-playbook-phantom-tools.md
+++ b/.changeset/speckit-playbook-phantom-tools.md
@@ -1,0 +1,14 @@
+---
+"@generacy-ai/agency-plugin-spec-kit": patch
+---
+
+fix(spec-kit): remove phantom MCP tool references from the speckit playbooks and wire the implement increment sentinel.
+
+The playbooks instructed agents to call four tools that do not exist anywhere in the agency server (`manage_clarification_labels`, `preflight_check`, `merge_from_base`, `update_phase_labels`), so every clarify/tasks/implement run paid for a failed tool call and improvised recovery — and the label steps (`waiting-for:clarification`, `waiting-for:manual-validation`) silently never happened.
+
+- clarify.md: labels are now managed via `gh issue edit`; the redundant second `manage_clarifications read` (which re-fetched the whole clarifications file just to read `pending_count`) is replaced with local bookkeeping.
+- tasks.md: epic auto-detection now reads issue labels via `gh issue view` instead of the nonexistent `preflight_check`.
+- implement.md: base-branch sync uses plain `git fetch`/`git merge`; the manual-validation block label uses `gh issue edit`; completion validation now points at the terse `build_validate`/`test_run_unit` MCP tools; and a new "Task Increment Boundaries (Headless Mode)" section instructs emitting the `SPECKIT_IMPLEMENT_PARTIAL: {...}` sentinel after ~10 tasks — the orchestrator has parsed this sentinel since generacy spec 360 (T004), but no playbook ever emitted it, so the fresh-session re-invoke mitigation for implement-phase context exhaustion could never trigger.
+- taskstoissues.md: the mandatory `dry_run: true` preview pass (up to ~15 KB of discarded body previews) is now interactive-only; headless runs create issues in a single call.
+
+Both command directories (`agency-plugin-spec-kit/commands` and `claude-plugin-agency-spec-kit/commands`) updated in lockstep, byte-identical.

--- a/packages/agency-plugin-spec-kit/commands/clarify.md
+++ b/packages/agency-plugin-spec-kit/commands/clarify.md
@@ -123,12 +123,11 @@ Call the `manage_clarifications` MCP tool with operation "append":
 
 ### Step 5a: Update Labels for Pending Questions
 
-After persisting questions, call `manage_clarification_labels` MCP tool to add the `waiting-for:clarification` label:
+After persisting questions, add the `waiting-for:clarification` label to the issue using the `gh` CLI:
 
 1. Extract the issue number from the current branch name (pattern: `###-*`, e.g., `155-feature-name` → `155`)
-2. Call `manage_clarification_labels` with:
-   - `issue_number`: The extracted issue number
-   - `has_pending_questions`: `true`
+2. Run: `gh issue edit <issue_number> --add-label "waiting-for:clarification"`
+3. If the command fails because the label does not exist in the repository, create it first (`gh label create "waiting-for:clarification" --color FBCA04 --description "Clarification questions pending answers"`) and retry once
 
 This ensures the workflow blocks until the user answers the questions.
 
@@ -180,15 +179,11 @@ If answers reveal new information that should be in spec.md:
 
 ### Step 7a: Update Labels When All Questions Answered
 
-After updating answers, check if all questions have been answered (no `*Pending*` answers remain):
+After updating answers, check whether all questions are now answered. Do NOT re-read the clarifications file — you already know the question list from Step 2 and which answers you just applied in Step 7; a question is still pending only if it had `*Pending*` in Step 2 and you did not update it.
 
-1. Call `manage_clarifications` with operation "read" to get updated `pending_count`
-2. If `pending_count` is 0 (all questions answered):
-   - Extract the issue number from the current branch name (pattern: `###-*`)
-   - Call `manage_clarification_labels` with:
-     - `issue_number`: The extracted issue number
-     - `has_pending_questions`: `false`
-   - This removes the `waiting-for:clarification` label
+If no pending questions remain:
+- Extract the issue number from the current branch name (pattern: `###-*`)
+- Run: `gh issue edit <issue_number> --remove-label "waiting-for:clarification"`
 
 **Note**: The `completed:clarification` label is added by the USER to signal they are done answering, not by the agent.
 
@@ -229,7 +224,7 @@ Where:
 When running as part of an speckit workflow, labels track clarification state:
 
 ### Label Lifecycle
-1. **Questions posted**: `waiting-for:clarification` label added to the issue (by agent via `manage_clarification_labels`)
+1. **Questions posted**: `waiting-for:clarification` label added to the issue (by agent via `gh issue edit`)
 2. **Developer answers**: Developer posts answers as issue comment, adds `completed:clarification` label
 3. **Agent resumes**: Agent reads answers from GitHub, processes them, may ask follow-ups or complete
 

--- a/packages/agency-plugin-spec-kit/commands/implement.md
+++ b/packages/agency-plugin-spec-kit/commands/implement.md
@@ -79,12 +79,12 @@ Execute the implementation plan by processing tasks defined in tasks.md.
 6a. **Merge at priority phase boundaries** (P1→P2, P2→P3):
    - When transitioning between priority phases (e.g., after all P1 tasks, before starting P2):
      1. Commit current work with message: `feat: Complete [phase] tasks for #<issue>`
-     2. Call `merge_from_base` MCP tool to sync with latest develop/main
-     3. If conflicts detected:
-        - The tool returns conflict details for agent resolution
+     2. Sync with the latest base branch: `git fetch origin` then `git merge origin/<base>` (where `<base>` is the branch this feature branched from — usually `develop`, or `main` if the repo has no develop branch)
+     3. If the merge reports conflicts:
+        - Run `git status` to list conflicted files
         - Analyze each conflict in context of the work just completed
         - Resolve conflicts by editing files (preserve local implementation intent)
-        - Stage resolved files with `git add`
+        - Stage resolved files with `git add`, then `git commit` to conclude the merge
         - If conflicts are semantic (contradictory intent), report to user
      4. Log merge result (one line for success)
      5. Continue with next priority phase
@@ -166,7 +166,7 @@ Execute the implementation plan by processing tasks defined in tasks.md.
 
 9. **Completion validation**:
    - Verify all tasks completed
-   - Run any defined tests
+   - Run any defined tests — prefer the `build_validate` and `test_run_unit` MCP tools over raw shell commands: they return a one-line result on success and only the failure tail on failure, keeping the session small
    - Report final status with summary
 
    **Note**: After reporting, check your todo list for any remaining parent workflow steps.
@@ -178,10 +178,8 @@ Execute the implementation plan by processing tasks defined in tasks.md.
       2. **Medium confidence**: Contains keywords: "manual", "manually", "hand-test", "manual testing", "manually verify"
     - Count automated vs manual remaining tasks
     - **If ALL remaining incomplete tasks are manual** (automated=0, manual>0):
-      - Call `update_phase_labels` MCP tool with:
-        - `issue_number`: Extract from branch name or context
-        - `phase: "manual-validation"`
-        - `action: "block"`
+      - Extract the issue number from the branch name (pattern: `###-*`) or context
+      - Run: `gh issue edit <issue_number> --add-label "waiting-for:manual-validation"` (if the label does not exist in the repository, create it with `gh label create` and retry once)
       - Report: "✓ All automated tasks complete. Manual tasks remaining:"
       - List each remaining manual task
       - Add: "Added `waiting-for:manual-validation` label. Complete manual tasks, then add `completed:manual-validation` label to resume workflow."
@@ -204,6 +202,25 @@ Execute the implementation plan by processing tasks defined in tasks.md.
       - Skip steps 4-10
       - Exit immediately - do not re-process completed tasks
     - This prevents re-running implementation on an already-complete task list
+
+## Task Increment Boundaries (Headless Mode)
+
+Applies only in headless mode (invoked with `--headless` or with the environment variable `CLAUDE_HEADLESS=true`). Interactive sessions ignore this section.
+
+Large task lists exhaust the session's context window mid-implementation, losing uncommitted work. In headless mode, implement in bounded increments instead:
+
+1. At the start of execution, count incomplete tasks. If **more than 10** are incomplete, plan to complete at most 10 in this session. Respect phase ordering, and finish the current parallel batch rather than splitting it (slight overrun is fine).
+2. After completing the increment, make sure every finished task is marked complete in tasks.md (step 7). Do not start the next task.
+3. Output the sentinel below as the **final line** of your response, then stop:
+
+   ```
+   SPECKIT_IMPLEMENT_PARTIAL: {"partial":true,"tasks_completed":<N>,"tasks_remaining":<M>,"tasks_total":<T>}
+   ```
+
+   - The prefix `SPECKIT_IMPLEMENT_PARTIAL: ` is literal, case-sensitive, with exactly one space after the colon
+   - The payload is single-line JSON: `tasks_completed` = tasks finished this session, `tasks_remaining` = incomplete tasks still in tasks.md, `tasks_total` = all tasks
+4. The orchestrator detects the sentinel, commits and pushes the work in progress, and re-invokes `/implement` with a fresh session. Already-completed tasks are skipped on resume (see step 10a), so increments are idempotent.
+5. Never emit the sentinel when all tasks are complete — a full completion runs steps 9-10 normally and produces no sentinel.
 
 ## Constraints
 

--- a/packages/agency-plugin-spec-kit/commands/tasks.md
+++ b/packages/agency-plugin-spec-kit/commands/tasks.md
@@ -23,10 +23,10 @@ Generate an actionable, dependency-ordered task list from the implementation pla
    - If neither flag → proceed to auto-detection
 
 2. **Auto-detect epic context** (only if no flags):
-   - Call `preflight_check` MCP tool with the current issue URL
-   - Check the response for `epic_context.is_epic`
-   - If `epic_context.is_epic == true` → `epic_mode = true`
-   - Otherwise → `epic_mode = false`
+   - Extract the issue number from the issue URL argument or the current branch name (pattern: `###-*`)
+   - Run: `gh issue view <issue_number> --json labels --jq '[.labels[].name]'`
+   - If the labels include `epic` or `process:speckit-epic` → `epic_mode = true`
+   - Otherwise (including when no issue number can be determined) → `epic_mode = false`
 
 3. **Report mode selection**:
    - If epic mode: "📦 Epic mode: Generating coarse-grained task groups (2-8 hours each)"

--- a/packages/agency-plugin-spec-kit/commands/taskstoissues.md
+++ b/packages/agency-plugin-spec-kit/commands/taskstoissues.md
@@ -80,14 +80,16 @@ This command respects the tasks-review gate for epic issues:
    ```
 
 6. **Create issues using `tasks_to_issues` MCP tool**:
-   - Call the `tasks_to_issues` MCP tool with:
-     - `grouping`: The user's chosen strategy (`per-task`, `per-story`, or `per-phase`)
-     - `dry_run`: Set to `true` first to preview issues
+   - **Headless mode** (see detection note below): call the tool ONCE with `dry_run: false`. Do not do a dry-run pass — there is no user to review the preview, and the preview payload is large.
+   - **Interactive mode**: optionally call the tool with `dry_run: true` first, review the planned grouping with the user, and call again with `dry_run: false` once they confirm.
+   - Parameters for the real call:
+     - `grouping`: The chosen strategy (`per-task`, `per-story`, or `per-phase`)
+     - `dry_run`: `false`
      - `epic_number`: The epic issue number (if applicable)
      - `feature_dir`: Path to the feature directory (from step 1)
-   - Review the dry-run output with user
-   - If user confirms, call `tasks_to_issues` again with `dry_run: false` to create issues
    - The MCP tool handles label creation and dependency linking automatically
+
+   **Headless detection**: you are in headless mode if invoked with the `--headless` flag OR the environment variable `CLAUDE_HEADLESS` is set to `true`.
 
 7. **Update tasks.md** (optional):
    - Add issue links to tasks

--- a/packages/claude-plugin-agency-spec-kit/commands/clarify.md
+++ b/packages/claude-plugin-agency-spec-kit/commands/clarify.md
@@ -123,12 +123,11 @@ Call the `manage_clarifications` MCP tool with operation "append":
 
 ### Step 5a: Update Labels for Pending Questions
 
-After persisting questions, call `manage_clarification_labels` MCP tool to add the `waiting-for:clarification` label:
+After persisting questions, add the `waiting-for:clarification` label to the issue using the `gh` CLI:
 
 1. Extract the issue number from the current branch name (pattern: `###-*`, e.g., `155-feature-name` → `155`)
-2. Call `manage_clarification_labels` with:
-   - `issue_number`: The extracted issue number
-   - `has_pending_questions`: `true`
+2. Run: `gh issue edit <issue_number> --add-label "waiting-for:clarification"`
+3. If the command fails because the label does not exist in the repository, create it first (`gh label create "waiting-for:clarification" --color FBCA04 --description "Clarification questions pending answers"`) and retry once
 
 This ensures the workflow blocks until the user answers the questions.
 
@@ -180,15 +179,11 @@ If answers reveal new information that should be in spec.md:
 
 ### Step 7a: Update Labels When All Questions Answered
 
-After updating answers, check if all questions have been answered (no `*Pending*` answers remain):
+After updating answers, check whether all questions are now answered. Do NOT re-read the clarifications file — you already know the question list from Step 2 and which answers you just applied in Step 7; a question is still pending only if it had `*Pending*` in Step 2 and you did not update it.
 
-1. Call `manage_clarifications` with operation "read" to get updated `pending_count`
-2. If `pending_count` is 0 (all questions answered):
-   - Extract the issue number from the current branch name (pattern: `###-*`)
-   - Call `manage_clarification_labels` with:
-     - `issue_number`: The extracted issue number
-     - `has_pending_questions`: `false`
-   - This removes the `waiting-for:clarification` label
+If no pending questions remain:
+- Extract the issue number from the current branch name (pattern: `###-*`)
+- Run: `gh issue edit <issue_number> --remove-label "waiting-for:clarification"`
 
 **Note**: The `completed:clarification` label is added by the USER to signal they are done answering, not by the agent.
 
@@ -229,7 +224,7 @@ Where:
 When running as part of an speckit workflow, labels track clarification state:
 
 ### Label Lifecycle
-1. **Questions posted**: `waiting-for:clarification` label added to the issue (by agent via `manage_clarification_labels`)
+1. **Questions posted**: `waiting-for:clarification` label added to the issue (by agent via `gh issue edit`)
 2. **Developer answers**: Developer posts answers as issue comment, adds `completed:clarification` label
 3. **Agent resumes**: Agent reads answers from GitHub, processes them, may ask follow-ups or complete
 

--- a/packages/claude-plugin-agency-spec-kit/commands/implement.md
+++ b/packages/claude-plugin-agency-spec-kit/commands/implement.md
@@ -79,12 +79,12 @@ Execute the implementation plan by processing tasks defined in tasks.md.
 6a. **Merge at priority phase boundaries** (P1→P2, P2→P3):
    - When transitioning between priority phases (e.g., after all P1 tasks, before starting P2):
      1. Commit current work with message: `feat: Complete [phase] tasks for #<issue>`
-     2. Call `merge_from_base` MCP tool to sync with latest develop/main
-     3. If conflicts detected:
-        - The tool returns conflict details for agent resolution
+     2. Sync with the latest base branch: `git fetch origin` then `git merge origin/<base>` (where `<base>` is the branch this feature branched from — usually `develop`, or `main` if the repo has no develop branch)
+     3. If the merge reports conflicts:
+        - Run `git status` to list conflicted files
         - Analyze each conflict in context of the work just completed
         - Resolve conflicts by editing files (preserve local implementation intent)
-        - Stage resolved files with `git add`
+        - Stage resolved files with `git add`, then `git commit` to conclude the merge
         - If conflicts are semantic (contradictory intent), report to user
      4. Log merge result (one line for success)
      5. Continue with next priority phase
@@ -166,7 +166,7 @@ Execute the implementation plan by processing tasks defined in tasks.md.
 
 9. **Completion validation**:
    - Verify all tasks completed
-   - Run any defined tests
+   - Run any defined tests — prefer the `build_validate` and `test_run_unit` MCP tools over raw shell commands: they return a one-line result on success and only the failure tail on failure, keeping the session small
    - Report final status with summary
 
    **Note**: After reporting, check your todo list for any remaining parent workflow steps.
@@ -178,10 +178,8 @@ Execute the implementation plan by processing tasks defined in tasks.md.
       2. **Medium confidence**: Contains keywords: "manual", "manually", "hand-test", "manual testing", "manually verify"
     - Count automated vs manual remaining tasks
     - **If ALL remaining incomplete tasks are manual** (automated=0, manual>0):
-      - Call `update_phase_labels` MCP tool with:
-        - `issue_number`: Extract from branch name or context
-        - `phase: "manual-validation"`
-        - `action: "block"`
+      - Extract the issue number from the branch name (pattern: `###-*`) or context
+      - Run: `gh issue edit <issue_number> --add-label "waiting-for:manual-validation"` (if the label does not exist in the repository, create it with `gh label create` and retry once)
       - Report: "✓ All automated tasks complete. Manual tasks remaining:"
       - List each remaining manual task
       - Add: "Added `waiting-for:manual-validation` label. Complete manual tasks, then add `completed:manual-validation` label to resume workflow."
@@ -204,6 +202,25 @@ Execute the implementation plan by processing tasks defined in tasks.md.
       - Skip steps 4-10
       - Exit immediately - do not re-process completed tasks
     - This prevents re-running implementation on an already-complete task list
+
+## Task Increment Boundaries (Headless Mode)
+
+Applies only in headless mode (invoked with `--headless` or with the environment variable `CLAUDE_HEADLESS=true`). Interactive sessions ignore this section.
+
+Large task lists exhaust the session's context window mid-implementation, losing uncommitted work. In headless mode, implement in bounded increments instead:
+
+1. At the start of execution, count incomplete tasks. If **more than 10** are incomplete, plan to complete at most 10 in this session. Respect phase ordering, and finish the current parallel batch rather than splitting it (slight overrun is fine).
+2. After completing the increment, make sure every finished task is marked complete in tasks.md (step 7). Do not start the next task.
+3. Output the sentinel below as the **final line** of your response, then stop:
+
+   ```
+   SPECKIT_IMPLEMENT_PARTIAL: {"partial":true,"tasks_completed":<N>,"tasks_remaining":<M>,"tasks_total":<T>}
+   ```
+
+   - The prefix `SPECKIT_IMPLEMENT_PARTIAL: ` is literal, case-sensitive, with exactly one space after the colon
+   - The payload is single-line JSON: `tasks_completed` = tasks finished this session, `tasks_remaining` = incomplete tasks still in tasks.md, `tasks_total` = all tasks
+4. The orchestrator detects the sentinel, commits and pushes the work in progress, and re-invokes `/implement` with a fresh session. Already-completed tasks are skipped on resume (see step 10a), so increments are idempotent.
+5. Never emit the sentinel when all tasks are complete — a full completion runs steps 9-10 normally and produces no sentinel.
 
 ## Constraints
 

--- a/packages/claude-plugin-agency-spec-kit/commands/tasks.md
+++ b/packages/claude-plugin-agency-spec-kit/commands/tasks.md
@@ -23,10 +23,10 @@ Generate an actionable, dependency-ordered task list from the implementation pla
    - If neither flag → proceed to auto-detection
 
 2. **Auto-detect epic context** (only if no flags):
-   - Call `preflight_check` MCP tool with the current issue URL
-   - Check the response for `epic_context.is_epic`
-   - If `epic_context.is_epic == true` → `epic_mode = true`
-   - Otherwise → `epic_mode = false`
+   - Extract the issue number from the issue URL argument or the current branch name (pattern: `###-*`)
+   - Run: `gh issue view <issue_number> --json labels --jq '[.labels[].name]'`
+   - If the labels include `epic` or `process:speckit-epic` → `epic_mode = true`
+   - Otherwise (including when no issue number can be determined) → `epic_mode = false`
 
 3. **Report mode selection**:
    - If epic mode: "📦 Epic mode: Generating coarse-grained task groups (2-8 hours each)"

--- a/packages/claude-plugin-agency-spec-kit/commands/taskstoissues.md
+++ b/packages/claude-plugin-agency-spec-kit/commands/taskstoissues.md
@@ -80,14 +80,16 @@ This command respects the tasks-review gate for epic issues:
    ```
 
 6. **Create issues using `tasks_to_issues` MCP tool**:
-   - Call the `tasks_to_issues` MCP tool with:
-     - `grouping`: The user's chosen strategy (`per-task`, `per-story`, or `per-phase`)
-     - `dry_run`: Set to `true` first to preview issues
+   - **Headless mode** (see detection note below): call the tool ONCE with `dry_run: false`. Do not do a dry-run pass — there is no user to review the preview, and the preview payload is large.
+   - **Interactive mode**: optionally call the tool with `dry_run: true` first, review the planned grouping with the user, and call again with `dry_run: false` once they confirm.
+   - Parameters for the real call:
+     - `grouping`: The chosen strategy (`per-task`, `per-story`, or `per-phase`)
+     - `dry_run`: `false`
      - `epic_number`: The epic issue number (if applicable)
      - `feature_dir`: Path to the feature directory (from step 1)
-   - Review the dry-run output with user
-   - If user confirms, call `tasks_to_issues` again with `dry_run: false` to create issues
    - The MCP tool handles label creation and dependency linking automatically
+
+   **Headless detection**: you are in headless mode if invoked with the `--headless` flag OR the environment variable `CLAUDE_HEADLESS` is set to `true`.
 
 7. **Update tasks.md** (optional):
    - Add issue links to tasks


### PR DESCRIPTION
Part 2 of the agency MCP token-efficiency work (tool-output audit).

The speckit playbooks instructed agents to call **four MCP tools that don't exist anywhere in the agency server**: `manage_clarification_labels` (clarify, twice), `preflight_check` (tasks), `merge_from_base` and `update_phase_labels` (implement). A historical spec attributes them to a defunct "autodev plugin". Every affected run paid for a failed tool call plus improvised recovery — and the gate labels (`waiting-for:clarification`, `waiting-for:manual-validation`) silently never got applied, which is a correctness gap, not just a token one.

Changes (all four files updated identically in both `agency-plugin-spec-kit/commands/` and the `claude-plugin-agency-spec-kit/commands/` mirror; the 9-file set is unchanged so `commands.test.ts` still passes):

- **clarify.md** — label add/remove now uses `gh issue edit` (with create-on-missing fallback). The second full `manage_clarifications read` in Step 7a, which re-fetched every question and answer just to read `pending_count`, is replaced with local bookkeeping from the Step 2 read.
- **tasks.md** — epic auto-detection reads issue labels via `gh issue view --json labels` (`epic` / `process:speckit-epic`) instead of the nonexistent `preflight_check`.
- **implement.md** —
  - phase-boundary sync uses plain `git fetch` / `git merge origin/<base>` with hand-resolution instructions instead of `merge_from_base`;
  - the manual-validation block uses `gh issue edit --add-label`;
  - completion validation now prefers the terse `build_validate` / `test_run_unit` MCP tools over raw shell commands;
  - new **Task Increment Boundaries (Headless Mode)** section: after ~10 tasks, mark progress in tasks.md and emit `SPECKIT_IMPLEMENT_PARTIAL: {"partial":true,...}` as the final line. The orchestrator has parsed exactly this sentinel since generacy spec 360 (T004/`output-capture.ts`), but T007 — the playbook side — was never actually landed, so the fresh-session re-invoke mitigation for implement-phase context exhaustion (the failure mode that twice lost 7 tasks of work) could never trigger. This closes that gap.
- **taskstoissues.md** — the mandatory `dry_run: true` preview (up to ~15 KB of pretty-printed body previews, immediately discarded) is now interactive-only; headless runs create issues in one call.

Note: the two failing tests in `tests/integration/github-flow.test.ts` (T013/T014 `create_ticket`) fail identically on develop in this environment (live GitHub API auth) — unrelated to this markdown-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)