### PR TITLE
feat(modes): add speckit mode and --mode flag to scope the advertised tool surface

### DIFF
--- a/.changeset/speckit-mode-scoping.md
+++ b/.changeset/speckit-mode-scoping.md
@@ -1,0 +1,15 @@
+---
+"@generacy-ai/agency": minor
+"@generacy-ai/agency-plugin-npm": patch
+"@generacy-ai/agency-plugin-spec-kit": patch
+---
+
+feat(modes): add a `speckit` mode and a `--mode` CLI flag to scope the advertised tool surface for automated workflow sessions.
+
+A default (coding-mode) session advertises 49 tools ≈ 26 KB (~6.5k tokens) of definitions, of which the speckit playbooks use six. The new built-in `speckit` mode advertises only the 11 tools the workflows need — the six spec_kit workflow tools plus the terse `build.compile`/`build.validate`/`test.run_*` checks — measuring 11 tools ≈ 6 KB (~1.5k tokens), a 77% reduction in per-session definition cost.
+
+- `DEFAULT_MODE_PATTERNS` gains `speckit: []`: the empty pattern list excludes every tool that does not explicitly opt in via its `modes` array (so pattern-fallback families like docker and humancy are out by construction).
+- The CLI now accepts `--mode <name>`, and `AgencyServer.create` accepts `modeOverride` — an explicit invocation-level override that beats `defaultMode` from every config source (previously `AGENCY_DEFAULT_MODE` silently lost to any `.agency/config.json`). Unknown modes warn on stderr and keep the configured default.
+- The 11 workflow tools add `'speckit'` to their `modes` arrays.
+
+Also slims the heaviest spec_kit payloads: `get_ticket` and `tasks_to_issues` responses are now compact JSON instead of 2-space pretty-printed (tickets carry full issue bodies), and `manage_clarifications`' advertised schema drops a triple-nested per-field `questions` description (~0.9 KB of every tools/list) in favor of a one-line shape description — runtime behavior is unchanged since the tool validates parameters itself.

--- a/packages/agency-plugin-npm/src/tools/build/compile.ts
+++ b/packages/agency-plugin-npm/src/tools/build/compile.ts
@@ -20,7 +20,7 @@ export function createCompileTool(config: NpmPluginConfig): AgencyTool {
     inputSchema: zodToJsonSchema(CompileSchema),
     namespace: 'build',
     outputPattern: 'terse',
-    modes: ['default', 'coding'],
+    modes: ['default', 'coding', 'speckit'],
 
     async execute(params: unknown): Promise<ToolResult> {
       const parsed = CompileSchema.safeParse(params);

--- a/packages/agency-plugin-npm/src/tools/build/validate.ts
+++ b/packages/agency-plugin-npm/src/tools/build/validate.ts
@@ -108,7 +108,7 @@ export function createValidateTool(config: NpmPluginConfig): AgencyTool {
     inputSchema: zodToJsonSchema(ValidateSchema),
     namespace: 'build',
     outputPattern: 'terse',
-    modes: ['default', 'coding', 'review'],
+    modes: ['default', 'coding', 'review', 'speckit'],
 
     async execute(params: unknown): Promise<ToolResult> {
       const parsed = ValidateSchema.safeParse(params);

--- a/packages/agency-plugin-npm/src/tools/test/run-e2e.ts
+++ b/packages/agency-plugin-npm/src/tools/test/run-e2e.ts
@@ -20,7 +20,7 @@ export function createRunE2ETool(config: NpmPluginConfig): AgencyTool {
     inputSchema: zodToJsonSchema(RunE2ESchema),
     namespace: 'test',
     outputPattern: 'terse',
-    modes: ['default', 'coding'],
+    modes: ['default', 'coding', 'speckit'],
 
     async execute(params: unknown): Promise<ToolResult> {
       const parsed = RunE2ESchema.safeParse(params);

--- a/packages/agency-plugin-npm/src/tools/test/run-integration.ts
+++ b/packages/agency-plugin-npm/src/tools/test/run-integration.ts
@@ -20,7 +20,7 @@ export function createRunIntegrationTool(config: NpmPluginConfig): AgencyTool {
     inputSchema: zodToJsonSchema(RunIntegrationSchema),
     namespace: 'test',
     outputPattern: 'terse',
-    modes: ['default', 'coding'],
+    modes: ['default', 'coding', 'speckit'],
 
     async execute(params: unknown): Promise<ToolResult> {
       const parsed = RunIntegrationSchema.safeParse(params);

--- a/packages/agency-plugin-npm/src/tools/test/run-unit.ts
+++ b/packages/agency-plugin-npm/src/tools/test/run-unit.ts
@@ -20,7 +20,7 @@ export function createRunUnitTool(config: NpmPluginConfig): AgencyTool {
     inputSchema: zodToJsonSchema(RunUnitSchema),
     namespace: 'test',
     outputPattern: 'terse',
-    modes: ['default', 'coding'],
+    modes: ['default', 'coding', 'speckit'],
 
     async execute(params: unknown): Promise<ToolResult> {
       const parsed = RunUnitSchema.safeParse(params);

--- a/packages/agency-plugin-npm/tests/tools/build.test.ts
+++ b/packages/agency-plugin-npm/tests/tools/build.test.ts
@@ -101,7 +101,7 @@ describe('build tools', () => {
       expect(validate.name).toBe('build.validate');
       expect(validate.namespace).toBe('build');
       expect(validate.outputPattern).toBe('terse');
-      expect(validate.modes).toEqual(['default', 'coding', 'review']);
+      expect(validate.modes).toEqual(['default', 'coding', 'review', 'speckit']);
     });
 
     it('discovers validation scripts from package.json', async () => {

--- a/packages/agency-plugin-spec-kit/src/tools/check-prereqs.ts
+++ b/packages/agency-plugin-spec-kit/src/tools/check-prereqs.ts
@@ -191,7 +191,7 @@ export function createCheckPrereqsTool(
       'Check prerequisites for a command. Validates required files exist and returns list of available optional documents.',
     namespace: 'spec_kit',
     outputPattern: 'terse',
-    modes: ['coding', 'research'],
+    modes: ['coding', 'research', 'speckit'],
     inputSchema: {
       type: 'object',
       properties: {

--- a/packages/agency-plugin-spec-kit/src/tools/create-feature.ts
+++ b/packages/agency-plugin-spec-kit/src/tools/create-feature.ts
@@ -334,7 +334,7 @@ export function createCreateFeatureTool(
       'Create a new feature branch and initialize the spec directory with template files',
     namespace: 'spec_kit',
     outputPattern: 'terse',
-    modes: ['coding'],
+    modes: ['coding', 'speckit'],
     inputSchema: {
       type: 'object',
       properties: {

--- a/packages/agency-plugin-spec-kit/src/tools/get-paths.ts
+++ b/packages/agency-plugin-spec-kit/src/tools/get-paths.ts
@@ -153,7 +153,7 @@ export function createGetPathsTool(
     description: 'Get all feature paths for the current or specified branch',
     namespace: 'spec_kit',
     outputPattern: 'terse',
-    modes: ['coding', 'research'],
+    modes: ['coding', 'research', 'speckit'],
     inputSchema: {
       type: 'object',
       properties: {

--- a/packages/agency-plugin-spec-kit/src/tools/get-ticket.ts
+++ b/packages/agency-plugin-spec-kit/src/tools/get-ticket.ts
@@ -133,7 +133,9 @@ export function createGetTicketTool(
         content: [
           {
             type: 'text',
-            text: JSON.stringify(ticket, null, 2),
+            // Compact on purpose: tickets carry full issue bodies, and the
+            // 2-space indent inflated an already-large payload
+            text: JSON.stringify(ticket),
           },
         ],
       };

--- a/packages/agency-plugin-spec-kit/src/tools/manage-clarifications.ts
+++ b/packages/agency-plugin-spec-kit/src/tools/manage-clarifications.ts
@@ -457,7 +457,7 @@ export function createManageClarificationsTool(
       'Manage clarifications.md file - read, append questions, or update answers',
     namespace: 'spec_kit',
     outputPattern: 'terse',
-    modes: ['coding', 'research'],
+    modes: ['coding', 'research', 'speckit'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -477,43 +477,10 @@ export function createManageClarificationsTool(
         },
         questions: {
           type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              topic: {
-                type: 'string',
-                description: 'Short topic identifier',
-              },
-              context: {
-                type: 'string',
-                description: 'Why this question matters',
-              },
-              question: {
-                type: 'string',
-                description: 'The specific question',
-              },
-              options: {
-                type: 'array',
-                items: {
-                  type: 'object',
-                  properties: {
-                    label: {
-                      type: 'string',
-                      description: 'Option label (A, B, C, etc.)',
-                    },
-                    description: {
-                      type: 'string',
-                      description: 'Option description',
-                    },
-                  },
-                  required: ['label', 'description'],
-                },
-                description: 'Optional list of choices',
-              },
-            },
-            required: ['topic', 'context', 'question'],
-          },
-          description: "Questions to append (for 'append' operation)",
+          items: { type: 'object' },
+          description:
+            "Questions to append (for 'append' operation). Each item: " +
+            '{topic, context, question, options?: [{label, description}]}',
         },
         question_number: {
           type: 'number',

--- a/packages/agency-plugin-spec-kit/src/tools/tasks-to-issues.ts
+++ b/packages/agency-plugin-spec-kit/src/tools/tasks-to-issues.ts
@@ -145,7 +145,7 @@ function errorResult(
   };
 
   return {
-    content: [{ type: 'text', text: JSON.stringify(response, null, 2) }],
+    content: [{ type: 'text', text: JSON.stringify(response) }],
     isError: true,
   };
 }
@@ -155,7 +155,7 @@ function errorResult(
  */
 function successResult(data: TasksToIssuesResult): ToolResult {
   return {
-    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+    content: [{ type: 'text', text: JSON.stringify(data) }],
   };
 }
 
@@ -295,7 +295,7 @@ export function createTasksToIssuesTool(
       'Convert tasks from tasks.md into GitHub issues with configurable grouping strategies',
     namespace: 'spec_kit',
     outputPattern: 'terse',
-    modes: ['coding'],
+    modes: ['coding', 'speckit'],
     inputSchema: {
       type: 'object',
       properties: {

--- a/packages/agency-plugin-spec-kit/src/tools/update-agent.ts
+++ b/packages/agency-plugin-spec-kit/src/tools/update-agent.ts
@@ -456,7 +456,7 @@ export function createUpdateAgentTool(
       'Update AI agent context files with technology information from the current feature plan.md',
     namespace: 'spec_kit',
     outputPattern: 'terse',
-    modes: ['coding'],
+    modes: ['coding', 'speckit'],
     inputSchema: {
       type: 'object',
       properties: {

--- a/packages/agency-plugin-spec-kit/tests/get-ticket-tool.test.ts
+++ b/packages/agency-plugin-spec-kit/tests/get-ticket-tool.test.ts
@@ -162,14 +162,15 @@ describe('createGetTicketTool', () => {
       await expect(tool.execute({ ref: '#999' })).rejects.toThrow(NotFoundError);
     });
 
-    it('should return formatted JSON output', async () => {
+    it('should return compact JSON output', async () => {
       const tool = createGetTicketTool(config, getProvider);
 
       const result = await tool.execute({ ref: '#123' });
 
       const text = (result.content[0] as { text: string }).text;
-      // Should be pretty-printed JSON (contains newlines)
-      expect(text).toContain('\n');
+      // Compact single-line JSON (tickets carry full issue bodies; no indent)
+      expect(text).not.toContain('\n');
+      expect(JSON.parse(text)).toMatchObject({ title: 'Test Issue' });
     });
   });
 

--- a/packages/agency/src/cli.ts
+++ b/packages/agency/src/cli.ts
@@ -7,16 +7,26 @@
  * auto-discovery of plugins.
  *
  * Usage:
- *   npx @generacy-ai/agency
- *   node bin/agency.js
+ *   npx @generacy-ai/agency [--mode <name>]
+ *
+ * Flags:
+ *   --mode <name> - Start in the named mode (e.g. "speckit"), overriding
+ *                   defaultMode from every config source
  *
  * Environment variables:
  *   AGENCY_NAME - Server name (default: "agency")
  *   AGENCY_PLUGINS - Comma-separated list of plugins to load
- *   AGENCY_DEFAULT_MODE - Default mode (default: "default")
+ *   AGENCY_DEFAULT_MODE - Default mode (default: "coding"; overridden by
+ *                         .agency/config.json and by --mode)
  */
 
 import { AgencyServer } from './server/index.js';
+
+/** Extract the value of a `--flag value` pair from argv, if present */
+function argValue(argv: string[], flag: string): string | undefined {
+  const idx = argv.indexOf(flag);
+  return idx !== -1 ? argv[idx + 1] : undefined;
+}
 
 async function main(): Promise<void> {
   try {
@@ -24,6 +34,7 @@ async function main(): Promise<void> {
     const server = await AgencyServer.create({
       projectRoot: process.cwd(),
       autoLoadPlugins: true,
+      modeOverride: argValue(process.argv.slice(2), '--mode'),
     });
 
     // Handle graceful shutdown

--- a/packages/agency/src/config/schema.ts
+++ b/packages/agency/src/config/schema.ts
@@ -36,6 +36,10 @@ export const DEFAULT_MODE_PATTERNS: Record<string, string[]> = {
   coding: ['*'],
   review: ['*'],
   debug: ['*'],
+  // Minimal surface for automated speckit workflow sessions. The empty
+  // pattern list means tools WITHOUT an explicit `modes` array are excluded;
+  // only tools that opt in by listing 'speckit' in `modes` are advertised.
+  speckit: [],
 };
 
 /**

--- a/packages/agency/src/server/agency-server.test.ts
+++ b/packages/agency/src/server/agency-server.test.ts
@@ -65,6 +65,30 @@ describe('AgencyServer', () => {
     it('should use default mode from config', async () => {
       expect(server.getMode()).toBe('default');
     });
+
+    it('should start in the mode given by modeOverride', async () => {
+      const overridden = await AgencyServer.create({
+        config: testConfig,
+        modeOverride: 'dev',
+      });
+      expect(overridden.getMode()).toBe('dev');
+    });
+
+    it('should ignore an unknown modeOverride with a warning', async () => {
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+      try {
+        const overridden = await AgencyServer.create({
+          config: testConfig,
+          modeOverride: 'no-such-mode',
+        });
+        expect(overridden.getMode()).toBe('default');
+        expect(stderrSpy).toHaveBeenCalledWith(
+          expect.stringContaining("unknown mode 'no-such-mode'")
+        );
+      } finally {
+        stderrSpy.mockRestore();
+      }
+    });
   });
 
   describe('registerTool/unregisterTool', () => {

--- a/packages/agency/src/server/agency-server.ts
+++ b/packages/agency/src/server/agency-server.ts
@@ -50,6 +50,12 @@ export interface AgencyServerOptions {
 
   /** Whether to auto-discover and load plugins on start */
   autoLoadPlugins?: boolean;
+
+  /**
+   * Mode to start in, overriding `defaultMode` from every config source.
+   * Ignored with a stderr warning if the mode is not defined in `modes`.
+   */
+  modeOverride?: string;
 }
 
 /**
@@ -133,6 +139,17 @@ export class AgencyServer {
     } else {
       const loader = new ConfigLoader(options.projectRoot);
       config = await loader.load();
+    }
+
+    if (options.modeOverride) {
+      if (config.modes[options.modeOverride]) {
+        config = { ...config, defaultMode: options.modeOverride };
+      } else {
+        process.stderr.write(
+          `Agency: unknown mode '${options.modeOverride}' (available: ${Object.keys(config.modes).join(', ')}); ` +
+            `keeping '${config.defaultMode ?? 'default'}'\n`
+        );
+      }
     }
 
     return new AgencyServer(config, options);

--- a/packages/agency/src/tools/registry.test.ts
+++ b/packages/agency/src/tools/registry.test.ts
@@ -186,6 +186,17 @@ describe('ToolRegistry', () => {
       expect(tools).toEqual([]);
     });
 
+    it('should list only explicitly opted-in tools for an empty-pattern mode (speckit semantics)', () => {
+      registry.setModePatterns({ speckit: [] });
+      registry.register(createTestTool({ name: 'spec_kit.check_prereqs', modes: ['coding', 'speckit'] }));
+      registry.register(createTestTool({ name: 'humancy.notify' })); // no modes → pattern fallback
+      registry.register(createTestTool({ name: 'source_control.push', modes: ['coding'] }));
+
+      const tools = registry.getToolsForMode('speckit');
+
+      expect(tools.map((t) => t.name)).toEqual(['spec_kit.check_prereqs']);
+    });
+
     it('should support excludes patterns (excludes win over includes)', () => {
       registry.setModePatterns({
         restricted: {


### PR DESCRIPTION
Part 3 of the agency MCP token-efficiency work (tool-output audit).

A default (coding-mode) session advertises **49 tools / ~26 KB (~6.5k tokens)** of tool definitions. The speckit playbooks call exactly six of them; the git/docker/firebase/humancy families and five spec_kit tools have **zero external consumers** anywhere in the tetrad repos (verified by sweep). This PR scopes the surface instead of deleting anything:

- **New built-in `speckit` mode** (`DEFAULT_MODE_PATTERNS.speckit = []`): the empty pattern list means tools without an explicit `modes` array (docker, humancy) are excluded by construction, and only tools listing `'speckit'` are advertised. The 11 workflow tools opt in: the six spec_kit tools the playbooks call plus `build.compile`, `build.validate`, `test.run_unit/integration/e2e` (the terse checks implement.md now points at, see #493).
- **`--mode <name>` CLI flag** + `AgencyServer.create({ modeOverride })`: an invocation-level override that beats `defaultMode` from every config source. This was needed because `AGENCY_DEFAULT_MODE` silently loses to any `.agency/config.json` with a `defaultMode` key (priority merge in `ConfigLoader`). Unknown modes warn on stderr and keep the configured default rather than serving zero tools.
- **Payload slimming** on the heaviest spec_kit responses: `get_ticket` (full issue body, was 2-space pretty-printed) and both `tasks_to_issues` result paths now emit compact JSON; `manage_clarifications`' advertised input schema drops the triple-nested per-field `questions` object (~0.9 KB in every `tools/list`) for a one-line shape description — safe because the tool casts/validates params itself and never used the JSON schema at runtime.

**Measured** (real MCP handshake against the built server, `cwd=/workspaces/agency`):

| mode | tools | listing chars |
|---|---|---|
| coding (default) | 49 | 26,178 |
| speckit | 11 | 5,969 |

The verification also proves `--mode speckit` wins over this repo's own `.agency/config.json` (`defaultMode: coding`).

Companion PR in generacy passes `--mode speckit` in the `mcpServers.agency` entry written by `generacy setup build`. Old agency + new generacy is harmless (the flag was previously ignored argv); new agency + old generacy keeps today's coding-mode behavior.

Test plan: agency core 1,527 tests pass (incl. new modeOverride + empty-pattern-mode tests); npm plugin 42; spec-kit 852 (non-live; the 2 live `create_ticket` API-auth failures exist on develop). Lint + typecheck clean across all three packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)